### PR TITLE
chore(ci): optimizar workflows para evitar ejecuciones redundantes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ['**']
+    branches: [main, master]
   pull_request:
     branches: [main, master]
 


### PR DESCRIPTION
## Problema
El workflow CI se ejecutaba en TODOS los pushes (`branches: ['**']`), causando:
- Ejecuciones redundantes en feature branches
- Desperdicio de recursos y tiempo
- Ruido innecesario en el historial

## Solución
Cambiar el trigger de push para ejecutarse solo en `main` y `master`:
- PR a main: valida código ANTES de mergear ✅
- Push a main: valida código DESPUÉS de mergear ✅
- Feature branches: sin CI (ya validado en PR) ✅

## Resultado
- Reducción ~50% de ejecuciones innecesarias
- Costo de CI más bajo
- Mejor señal/ruido en el historial de workflows