### PR TITLE
Fix: eliminar warning de @apply en google-sync

### DIFF
--- a/client/src/routes/google-sync/+page.svelte
+++ b/client/src/routes/google-sync/+page.svelte
@@ -281,7 +281,5 @@
 </div>
 
 <style>
-  :global(body) {
-    @apply bg-gray-50;
-  }
+  /* Tailwind styles removed - full refactor pending (issue #33) */
 </style>


### PR DESCRIPTION
## Resumen

Elimina el warning de svelte-check causado por la directiva `@apply` de Tailwind en la página de google-sync.

## Problema

El proyecto no usa Tailwind CSS, pero la página de google-sync tenía un bloque `<style>` con `@apply bg-gray-50` que causaba:

```
Warn: Unknown at rule @apply (css)
```

## Solución

Se eliminó el bloque `@apply`. El refactor completo de la página para usar design tokens está pendiente en el issue #33.

## Verificación

```
npm run check
svelte-check found 0 errors and 0 warnings
```

🤖 Generated with [Claude Code](https://claude.ai/code)