### PR TITLE
fix(InvoiceCard): initialize form data in create mode

### DIFF
--- a/client/src/lib/components/InvoiceCard.svelte
+++ b/client/src/lib/components/InvoiceCard.svelte
@@ -126,12 +126,20 @@
   }
 
   // Inicializar al montar y cuando cambian los props de invoice
+  // Track si ya inicializamos en modo create (para no resetear al cambiar props)
+  let initializedInCreateMode = false;
+
   $effect(() => {
     // Leer invoice para trackear cambios (después de invalidateAll)
     const _ = invoice.cuit;
-    // Solo resetear si no estamos editando
+
+    // En modo view: resetear cuando no estamos editando
+    // En modo create: inicializar solo una vez al montar
     if (!editMode) {
       resetToInvoiceData();
+    } else if (isCreateMode && !initializedInCreateMode) {
+      resetToInvoiceData();
+      initializedInCreateMode = true;
     }
   });
 


### PR DESCRIPTION
## Summary
- Fixed bug where "Usar estos datos" from expected invoice didn't populate the form
- Root cause: `$effect` only called `resetToInvoiceData()` when `editMode=false`, but create mode starts with `editMode=true`
- Solution: Track initialization state and initialize once on mount in create mode

## Test plan
- [x] Open a file without invoice (e.g., `file:83`)
- [x] Click "Usar estos datos" on an expected invoice
- [x] Verify all fields are populated (CUIT, type, PV, number, date, total)
- [x] Verify emitter is pre-selected
- [x] Verify category is pre-selected if expected has one

Fixes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)