### PR TITLE
feat(search): consolidate filters into unified search box

### DIFF
--- a/client/src/lib/components/UnifiedSearchBox.svelte
+++ b/client/src/lib/components/UnifiedSearchBox.svelte
@@ -1,0 +1,449 @@
+<script lang="ts">
+  import { debounce, parseSearchQuery, type FilterNode, type ParseResult } from '$lib/search';
+
+  type Category = {
+    id: number;
+    key: string;
+    description: string;
+  };
+
+  type Emitter = {
+    name: string;
+    cuit?: string;
+  };
+
+  type HintItem = {
+    value: string;
+    label: string;
+    description?: string;
+  };
+
+  let {
+    value = $bindable(''),
+    onfilter,
+    categories = [],
+    emitters = [],
+    placeholder = 'Buscar: emisor:, fecha:, estado:, categoria:...',
+  }: {
+    value: string;
+    onfilter: (filters: FilterNode[]) => void;
+    categories?: Category[];
+    emitters?: Emitter[];
+    placeholder?: string;
+  } = $props();
+
+  let parsedResult = $state<ParseResult>({ filters: [], errors: [] });
+  let inputRef = $state<HTMLInputElement | null>(null);
+  let isFocused = $state(false);
+
+  // Detectar si estamos escribiendo un campo con hints
+  let activeHintField = $derived(detectActiveHintField(value));
+  let hints = $derived(generateHints(activeHintField, categories, emitters));
+  let selectedHintIndex = $state(0);
+
+  // Debounce de parsing (300ms)
+  const debouncedParse = debounce((query: string) => {
+    parsedResult = parseSearchQuery(query);
+    onfilter(parsedResult.filters);
+  }, 300);
+
+  // Efecto que dispara el parsing cuando cambia el valor
+  $effect(() => {
+    debouncedParse(value);
+  });
+
+  // Reset selected hint when hints change
+  $effect(() => {
+    if (hints.length > 0) {
+      selectedHintIndex = 0;
+    }
+  });
+
+  function clearSearch() {
+    value = '';
+    inputRef?.focus();
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (!hints.length) return;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        selectedHintIndex = (selectedHintIndex + 1) % hints.length;
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        selectedHintIndex = (selectedHintIndex - 1 + hints.length) % hints.length;
+        break;
+      case 'Tab':
+      case 'Enter':
+        if (activeHintField && hints[selectedHintIndex]) {
+          e.preventDefault();
+          applyHint(hints[selectedHintIndex]);
+        }
+        break;
+      case 'Escape':
+        e.preventDefault();
+        isFocused = false;
+        inputRef?.blur();
+        break;
+    }
+  }
+
+  function applyHint(hint: HintItem) {
+    if (!activeHintField) return;
+
+    // Reemplazar el campo incompleto con el valor del hint
+    const lastSpaceIndex = value.lastIndexOf(' ');
+    const beforeLastToken = lastSpaceIndex >= 0 ? value.slice(0, lastSpaceIndex + 1) : '';
+
+    value = `${beforeLastToken}${activeHintField.field}:${hint.value} `;
+    selectedHintIndex = 0;
+    inputRef?.focus();
+  }
+
+  /**
+   * Detecta si el usuario está escribiendo un campo que tiene hints disponibles
+   * Retorna el campo y el valor parcial, o null si no hay hint activo
+   */
+  function detectActiveHintField(query: string): { field: string; partial: string } | null {
+    if (!query) return null;
+
+    // Obtener el último token
+    const tokens = query.split(/\s+/);
+    const lastToken = tokens[tokens.length - 1];
+
+    if (!lastToken) return null;
+
+    // Verificar si es un campo con ":"
+    const match = lastToken.match(/^(!?)(\w+):(.*)$/);
+    if (!match) return null;
+
+    const [, , field, partial] = match;
+    const fieldLower = field.toLowerCase();
+
+    // Campos que tienen hints
+    const fieldsWithHints = ['estado', 'emisor', 'categoria', 'tipo'];
+    if (!fieldsWithHints.includes(fieldLower)) return null;
+
+    return { field: fieldLower, partial: partial.toLowerCase() };
+  }
+
+  /**
+   * Genera las sugerencias basadas en el campo activo
+   */
+  function generateHints(
+    activeField: { field: string; partial: string } | null,
+    cats: Category[],
+    emits: Emitter[]
+  ): HintItem[] {
+    if (!activeField) return [];
+
+    const { field, partial } = activeField;
+
+    switch (field) {
+      case 'estado':
+        return filterHints(
+          [
+            { value: 'pendientes', label: 'Pendientes', description: 'Archivos sin procesar' },
+            { value: 'reconocidas', label: 'Reconocidas', description: 'Facturas confirmadas' },
+            { value: 'esperadas', label: 'Esperadas', description: 'Facturas por recibir' },
+          ],
+          partial
+        );
+
+      case 'categoria':
+        const catHints: HintItem[] = [
+          { value: 'sin', label: 'Sin categoría', description: 'Facturas sin clasificar' },
+          ...cats.map((c) => ({
+            value: c.key || c.description.toLowerCase().replace(/\s+/g, '-'),
+            label: c.description,
+          })),
+        ];
+        return filterHints(catHints, partial);
+
+      case 'emisor':
+        const emitterHints: HintItem[] = emits.map((e) => ({
+          value: e.name.toLowerCase(),
+          label: e.name,
+          description: e.cuit,
+        }));
+        return filterEmitterHints(emitterHints, partial);
+
+      case 'tipo':
+        return filterHints(
+          [
+            { value: 'faca', label: 'FACA', description: 'Factura A' },
+            { value: 'facb', label: 'FACB', description: 'Factura B' },
+            { value: 'facc', label: 'FACC', description: 'Factura C' },
+            { value: 'nca', label: 'NCA', description: 'Nota de crédito A' },
+            { value: 'ncb', label: 'NCB', description: 'Nota de crédito B' },
+            { value: 'nda', label: 'NDA', description: 'Nota de débito A' },
+            { value: 'ndb', label: 'NDB', description: 'Nota de débito B' },
+          ],
+          partial
+        );
+
+      default:
+        return [];
+    }
+  }
+
+  function filterHints(items: HintItem[], partial: string): HintItem[] {
+    if (!partial) return items.slice(0, 6);
+
+    return items
+      .filter(
+        (item) =>
+          item.value.toLowerCase().includes(partial) || item.label.toLowerCase().includes(partial)
+      )
+      .slice(0, 6);
+  }
+
+  /**
+   * Filtra emisores priorizando los que empiezan con el texto buscado
+   */
+  function filterEmitterHints(items: HintItem[], partial: string): HintItem[] {
+    if (!partial) return items.slice(0, 6);
+
+    const partialLower = partial.toLowerCase();
+
+    // Filtrar los que contienen el texto
+    const matches = items.filter(
+      (item) =>
+        item.label.toLowerCase().includes(partialLower) ||
+        (item.description && item.description.includes(partial)) // CUIT
+    );
+
+    // Ordenar: primero los que empiezan con el texto, luego alfabéticamente
+    matches.sort((a, b) => {
+      const aStartsWith = a.label.toLowerCase().startsWith(partialLower);
+      const bStartsWith = b.label.toLowerCase().startsWith(partialLower);
+
+      if (aStartsWith && !bStartsWith) return -1;
+      if (!aStartsWith && bStartsWith) return 1;
+      return a.label.localeCompare(b.label);
+    });
+
+    return matches.slice(0, 6);
+  }
+</script>
+
+<div class="unified-search-box">
+  <div class="search-container" class:focused={isFocused}>
+    <span class="search-icon">🔍</span>
+    <input
+      bind:this={inputRef}
+      type="text"
+      bind:value
+      {placeholder}
+      class="search-input"
+      aria-label="Buscar comprobantes"
+      onfocus={() => (isFocused = true)}
+      onblur={() => setTimeout(() => (isFocused = false), 150)}
+      onkeydown={handleKeydown}
+    />
+
+    {#if value}
+      <button class="clear-btn" onclick={clearSearch} aria-label="Limpiar búsqueda" type="button">
+        ✕
+      </button>
+    {/if}
+  </div>
+
+  <!-- Hints contextuales -->
+  {#if isFocused && hints.length > 0}
+    <div class="hints-panel" role="listbox">
+      <div class="hints-header">
+        Sugerencias para <code>{activeHintField?.field}:</code>
+      </div>
+      {#each hints as hint, i}
+        <button
+          type="button"
+          class="hint-item"
+          class:selected={i === selectedHintIndex}
+          role="option"
+          aria-selected={i === selectedHintIndex}
+          onmousedown={() => applyHint(hint)}
+          onmouseenter={() => (selectedHintIndex = i)}
+        >
+          <span class="hint-value">{hint.label}</span>
+          {#if hint.description}
+            <span class="hint-description">{hint.description}</span>
+          {/if}
+        </button>
+      {/each}
+      <div class="hints-footer">
+        <kbd>↑↓</kbd> navegar <kbd>Tab</kbd> seleccionar <kbd>Esc</kbd> cerrar
+      </div>
+    </div>
+  {/if}
+
+  <!-- Errores de parsing -->
+  {#if parsedResult.errors.length > 0}
+    <div class="error-hints">
+      {#each parsedResult.errors as error}
+        <span class="error-hint">{error}</span>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .unified-search-box {
+    width: 100%;
+    position: relative;
+  }
+
+  .search-container {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--spacing-2);
+    padding: var(--spacing-2) var(--spacing-3);
+    min-height: 48px;
+    border: 2px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    transition: all var(--transition-fast);
+  }
+
+  .search-container.focused {
+    border-color: var(--color-primary-500);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  }
+
+  .search-icon {
+    font-size: 1.1rem;
+    color: var(--color-text-tertiary);
+    flex-shrink: 0;
+  }
+
+  .search-input {
+    flex: 1;
+    min-width: 150px;
+    border: none;
+    background: transparent;
+    font-size: 16px;
+    font-family: var(--font-sans);
+    outline: none;
+    padding: var(--spacing-1) 0;
+  }
+
+  .search-input::placeholder {
+    color: var(--color-text-tertiary);
+    font-size: var(--font-size-sm);
+  }
+
+  .clear-btn {
+    background: transparent;
+    border: none;
+    color: var(--color-text-tertiary);
+    cursor: pointer;
+    font-size: 16px;
+    padding: var(--spacing-1);
+    border-radius: var(--radius-sm);
+    transition: all var(--transition-fast);
+    flex-shrink: 0;
+  }
+
+  .clear-btn:hover {
+    color: var(--color-text-primary);
+    background: var(--color-surface-alt);
+  }
+
+  /* Hints panel */
+  .hints-panel {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin-top: var(--spacing-2);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    z-index: 100;
+    overflow: hidden;
+  }
+
+  .hints-header {
+    padding: var(--spacing-2) var(--spacing-3);
+    background: var(--color-surface-alt);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .hints-header code {
+    background: var(--color-surface);
+    padding: 2px 6px;
+    border-radius: var(--radius-sm);
+    font-family: monospace;
+    color: var(--color-primary-700);
+  }
+
+  .hint-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: var(--spacing-2) var(--spacing-3);
+    border: none;
+    background: transparent;
+    text-align: left;
+    cursor: pointer;
+    transition: background var(--transition-fast);
+  }
+
+  .hint-item:hover,
+  .hint-item.selected {
+    background: var(--color-primary-50);
+  }
+
+  .hint-value {
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-primary);
+  }
+
+  .hint-description {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+  }
+
+  .hints-footer {
+    padding: var(--spacing-2) var(--spacing-3);
+    background: var(--color-surface-alt);
+    font-size: var(--font-size-xs);
+    color: var(--color-text-tertiary);
+    border-top: 1px solid var(--color-border);
+    display: flex;
+    gap: var(--spacing-3);
+  }
+
+  .hints-footer kbd {
+    display: inline-block;
+    padding: 2px 5px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    font-family: monospace;
+    font-size: var(--font-size-xs);
+  }
+
+  /* Error hints */
+  .error-hints {
+    margin-top: var(--spacing-2);
+    padding: var(--spacing-2) var(--spacing-3);
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    border-radius: var(--radius-md);
+  }
+
+  .error-hint {
+    display: block;
+    font-size: var(--font-size-sm);
+    color: #dc2626;
+  }
+</style>

--- a/client/src/lib/search/filter-executor.ts
+++ b/client/src/lib/search/filter-executor.ts
@@ -46,6 +46,9 @@ function evaluateFilterCondition(
     case 'tipo':
       return matchesTipo(c, filter.value);
 
+    case 'estado':
+      return matchesEstado(c, filter.value);
+
     case 'freetext':
       return matchesFreeText(c, filter.value);
 
@@ -227,6 +230,25 @@ function matchesTipo(c: Comprobante, query: string): boolean {
   }
 
   return false;
+}
+
+/**
+ * Match por estado del comprobante
+ */
+function matchesEstado(c: Comprobante, value: string): boolean {
+  switch (value) {
+    case 'pendientes':
+      // Archivos sin factura final
+      return !!c.file && !c.final;
+    case 'reconocidas':
+      // Facturas finalizadas o archivos procesados
+      return !!c.final || c.file?.status === 'processed';
+    case 'esperadas':
+      // Expected invoices sin factura final
+      return !!c.expected && !c.final;
+    default:
+      return false;
+  }
 }
 
 /**

--- a/client/src/lib/search/index.ts
+++ b/client/src/lib/search/index.ts
@@ -1,4 +1,4 @@
 export { parseSearchQuery, serializeFilters } from './query-parser';
-export type { FilterNode, DateRange, AmountRange, ParseResult } from './query-parser';
+export type { FilterNode, DateRange, AmountRange, ParseResult, EstadoValue } from './query-parser';
 export { createFilterMatcher } from './filter-executor';
 export { debounce } from './debounce';

--- a/client/src/lib/search/query-parser.ts
+++ b/client/src/lib/search/query-parser.ts
@@ -1,6 +1,11 @@
 import { startOfMonth, endOfMonth, startOfYear, endOfYear } from 'date-fns';
 
 /**
+ * Valores válidos para el filtro de estado
+ */
+export type EstadoValue = 'pendientes' | 'reconocidas' | 'esperadas';
+
+/**
  * Tipos de nodos de filtro soportados
  */
 export type FilterNode =
@@ -20,6 +25,7 @@ export type FilterNode =
       negate: boolean;
     }
   | { type: 'tipo'; value: string; negate: boolean }
+  | { type: 'estado'; value: EstadoValue; negate: boolean }
   | { type: 'freetext'; value: string; negate: boolean };
 
 export type DateRange = { start: Date; end: Date };
@@ -80,6 +86,8 @@ export function serializeFilters(filters: FilterNode[]): string {
           return `${prefix}numero:${f.value}`;
         case 'tipo':
           return `${prefix}tipo:${f.value}`;
+        case 'estado':
+          return `${prefix}estado:${f.value}`;
         case 'fecha':
           return `${prefix}fecha:${serializeDateFilter(f)}`;
         case 'total':
@@ -195,6 +203,9 @@ function parseToken(token: string): FilterNode | null {
         negate,
       };
 
+    case 'estado':
+      return parseEstadoField(value, negate);
+
     default:
       // Campo desconocido → tratar como texto libre
       return {
@@ -303,6 +314,43 @@ function parseDateField(value: string, negate: boolean): FilterNode {
     type: 'fecha',
     operator,
     value: parsedDate,
+    negate,
+  };
+}
+
+/**
+ * Valores válidos para estado con aliases
+ */
+const ESTADO_ALIASES: Record<string, EstadoValue> = {
+  pendiente: 'pendientes',
+  pendientes: 'pendientes',
+  pend: 'pendientes',
+  reconocida: 'reconocidas',
+  reconocidas: 'reconocidas',
+  rec: 'reconocidas',
+  procesada: 'reconocidas',
+  procesadas: 'reconocidas',
+  esperada: 'esperadas',
+  esperadas: 'esperadas',
+  esp: 'esperadas',
+};
+
+/**
+ * Parsea campo de estado
+ */
+function parseEstadoField(value: string, negate: boolean): FilterNode {
+  const valueLower = value.toLowerCase();
+  const estado = ESTADO_ALIASES[valueLower];
+
+  if (!estado) {
+    throw new Error(
+      `Estado inválido: ${value}. Valores válidos: pendientes, reconocidas, esperadas`
+    );
+  }
+
+  return {
+    type: 'estado',
+    value: estado,
     negate,
   };
 }

--- a/client/src/routes/comprobantes/+page.svelte
+++ b/client/src/routes/comprobantes/+page.svelte
@@ -2,8 +2,7 @@
   import Button from '$lib/components/ui/Button.svelte';
   import CategoryPills from '$lib/components/CategoryPills.svelte';
   import CompletenessIndicator from '$lib/components/CompletenessIndicator.svelte';
-  import SearchBox from '$lib/components/SearchBox.svelte';
-  import ActiveFilters from '$lib/components/ActiveFilters.svelte';
+  import UnifiedSearchBox from '$lib/components/UnifiedSearchBox.svelte';
   import UploadReport from '$lib/components/UploadReport.svelte';
   import type { PageData } from './$types';
   import type { Comprobante } from '$lib/types/comprobante';
@@ -20,44 +19,43 @@
     formatComprobanteKind,
     formatCuit,
   } from '$lib/formatters';
-  import { createFilterMatcher, serializeFilters, type FilterNode } from '$lib/search';
+  import { createFilterMatcher, type FilterNode } from '$lib/search';
   import { navigationStore } from '$lib/stores/navigation';
 
   let { data } = $props();
   let categories = $derived(data.categories || []);
-  // null => Sin categoría; undefined => todas; number => específica
-  let activeCategoryId = $state<number | undefined | null>(undefined);
 
   // Track which invoice is being edited for category
   let editingCategoryId = $state<number | null>(null);
 
-  type FilterKind = 'all' | 'pendientes' | 'reconocidas' | 'esperadas';
-
-  // Cargar filtro desde la URL (?f=...) o localStorage; por defecto 'all'
-  let activeFilter = $state<FilterKind>('all');
-
-  // Estado para búsqueda meta-lenguaje
+  // Estado unificado para búsqueda meta-lenguaje (incluye estado y categoría)
   let searchQuery = $state('');
   let searchFilters = $state<FilterNode[]>([]);
 
   // Filter matcher
   const matchesSearchFilter = $derived(createFilterMatcher(categories));
 
+  // Extraer lista de emisores únicos de los comprobantes
+  let emitters = $derived(() => {
+    const seen = new Set<string>();
+    const result: Array<{ name: string; cuit?: string }> = [];
+
+    for (const c of data.comprobantes) {
+      const name = c.emitterName || c.final?.emitterName || c.expected?.emitterName;
+      const cuit = c.emitterCuit || c.final?.cuit || c.expected?.cuit;
+
+      if (name && !seen.has(name)) {
+        seen.add(name);
+        result.push({ name, cuit: cuit ?? undefined });
+      }
+    }
+
+    return result.sort((a, b) => a.name.localeCompare(b.name));
+  });
+
+  // Restaurar query de búsqueda desde URL o localStorage
   $effect.pre(() => {
     if (typeof window !== 'undefined') {
-      const rawParam = $page.url.searchParams.get('f');
-      // Mapear alias legacy 'procesadas' -> 'reconocidas'
-      const urlParam = (rawParam === 'procesadas' ? 'reconocidas' : rawParam) as FilterKind | null;
-      let saved = localStorage.getItem('comprobantes-filter');
-      if (saved === 'procesadas') saved = 'reconocidas';
-      const valid = ['all', 'pendientes', 'reconocidas', 'esperadas'];
-      const initial =
-        urlParam && valid.includes(urlParam)
-          ? (urlParam as FilterKind)
-          : (saved as FilterKind | null) || 'all';
-      activeFilter = initial as FilterKind;
-
-      // Restaurar query de búsqueda desde URL
       const q = $page.url.searchParams.get('q');
       if (q) {
         searchQuery = q;
@@ -67,7 +65,7 @@
         if (savedFilters) {
           try {
             const state = JSON.parse(savedFilters);
-            if (state.version === 1 && Date.now() - state.timestamp < 7 * 24 * 60 * 60 * 1000) {
+            if (state.version === 2 && Date.now() - state.timestamp < 7 * 24 * 60 * 60 * 1000) {
               searchQuery = state.query || '';
             }
           } catch (e) {
@@ -78,37 +76,23 @@
     }
   });
 
-  // Persistir filtros de búsqueda en localStorage
+  // Persistir filtros de búsqueda en localStorage y URL
   $effect(() => {
     if (typeof window !== 'undefined') {
       const state = {
-        version: 1,
+        version: 2,
         query: searchQuery,
-        categoryId: activeCategoryId,
-        statusFilter: activeFilter,
         timestamp: Date.now(),
       };
       localStorage.setItem('comprobantes-search-filters', JSON.stringify(state));
-    }
-  });
 
-  // Sincronizar cambios de filtro con URL y localStorage (SPA)
-  async function updateUrlForFilter(kind: FilterKind) {
-    const current = $state.snapshot(activeFilter);
-    if (current === kind) return;
-    activeFilter = kind;
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('comprobantes-filter', kind);
-
+      // Actualizar URL sin recargar
       const params = new URLSearchParams();
       if (searchQuery) params.set('q', searchQuery);
-      if (kind !== 'all') params.set('f', kind);
-
       const target = params.toString() ? `/comprobantes?${params}` : '/comprobantes';
-      // Reemplazar estado para no ensuciar el historial al alternar filtros
-      await goto(target, { replaceState: true, noScroll: true, keepFocus: true });
+      goto(target, { replaceState: true, noScroll: true, keepFocus: true });
     }
-  }
+  });
 
   function shortHash(hash?: string | null) {
     if (!hash) return '—';
@@ -140,35 +124,10 @@
   }
 
   function isVisible(c: Comprobante): boolean {
-    switch (activeFilter) {
-      case 'reconocidas':
-        // Incluir facturas finalizadas y archivos procesados
-        if (!(!!c.final || c.file?.status === 'processed')) return false;
-        break;
-      case 'esperadas':
-        if (!(!!c.expected && !c.final)) return false;
-        break;
-      case 'pendientes':
-        // Mostrar todos los comprobantes de tipo pending (sin factura finalizada)
-        if (!c.file || c.final) return false;
-        break;
-      default:
-        break;
-    }
-    // Filtro por categoría (solo aplica a facturas finales)
-    if (activeCategoryId === null) {
-      // Filtrar facturas sin categoría
-      return (c.final?.categoryId ?? null) === null;
-    }
-    if (activeCategoryId !== undefined) {
-      return (c.final?.categoryId ?? null) === activeCategoryId;
-    }
-
-    // Filtros de búsqueda meta-lenguaje
+    // Todos los filtros se aplican via meta-lenguaje (AND lógico)
     for (const filter of searchFilters) {
       if (!matchesSearchFilter(c, filter)) return false;
     }
-
     return true;
   }
 
@@ -280,20 +239,11 @@
   // Helpers para búsqueda meta-lenguaje
   let visibleComprobantes = $derived(data.comprobantes.filter(isVisible));
 
-  let hasActiveFilters = $derived(
-    activeFilter !== 'all' || activeCategoryId !== undefined || searchFilters.length > 0
-  );
+  let hasActiveFilters = $derived(searchFilters.length > 0);
 
   function clearAllFilters() {
     searchQuery = '';
     searchFilters = [];
-    activeCategoryId = undefined;
-    updateUrlForFilter('all');
-  }
-
-  function removeFilter(filter: FilterNode) {
-    const remaining = searchFilters.filter((f) => f !== filter);
-    searchQuery = serializeFilters(remaining);
   }
 
   /**
@@ -302,7 +252,7 @@
   function navigateToDetail(compId: string) {
     // Guardar los IDs de la lista visible actual para navegación prev/next
     const ids = visibleComprobantes.map((c) => c.id);
-    navigationStore.setContext(ids, activeFilter);
+    navigationStore.setContext(ids, searchQuery || undefined);
     goto(`/comprobantes/${compId}`);
   }
 
@@ -434,73 +384,23 @@
     </div>
   {/if}
 
-  <!-- BÚSQUEDA META-LENGUAJE -->
+  <!-- BÚSQUEDA UNIFICADA -->
   <section class="search-section">
-    <SearchBox
+    <UnifiedSearchBox
       bind:value={searchQuery}
       onfilter={(filters) => (searchFilters = filters)}
       {categories}
+      emitters={emitters()}
     />
   </section>
 
-  <section class="filters">
-    <button
-      class:active={activeFilter === 'all'}
-      onclick={() => updateUrlForFilter('all')}
-      type="button"
-    >
-      Todos
-    </button>
-    <button
-      class:active={activeFilter === 'pendientes'}
-      onclick={() => updateUrlForFilter('pendientes')}
-      type="button"
-    >
-      Pendientes
-    </button>
-    <button
-      class:active={activeFilter === 'reconocidas'}
-      onclick={() => updateUrlForFilter('reconocidas')}
-      type="button"
-    >
-      Reconocidas
-    </button>
-    <button
-      class:active={activeFilter === 'esperadas'}
-      onclick={() => updateUrlForFilter('esperadas')}
-      type="button"
-    >
-      Esperadas
-    </button>
-  </section>
-
-  <!-- Filtro por categoría -->
-  <section class="filters">
-    <label for="category-filter">Categoría:</label>
-    <CategoryPills
-      {categories}
-      selected={activeCategoryId}
-      onselect={(id) => (activeCategoryId = id)}
-      mode="filter"
-    />
-  </section>
-
-  <!-- RESUMEN DE FILTROS + LIMPIAR -->
+  <!-- RESUMEN DE FILTROS -->
   {#if hasActiveFilters}
     <section class="filter-summary">
       <div class="count">
         Mostrando {visibleComprobantes.length} de {data.comprobantes.length} comprobantes
       </div>
-      <button class="clear-all" onclick={clearAllFilters} type="button">
-        Limpiar todos los filtros
-      </button>
-    </section>
-  {/if}
-
-  <!-- FILTROS ACTIVOS VISUALES -->
-  {#if searchFilters.length > 0}
-    <section class="active-filters-section">
-      <ActiveFilters filters={searchFilters} onremove={removeFilter} />
+      <button class="clear-all" onclick={clearAllFilters} type="button"> Limpiar filtros </button>
     </section>
   {/if}
 
@@ -695,29 +595,6 @@
   .dz-hint {
     margin: 0;
     color: var(--color-text-tertiary);
-  }
-
-  .filters {
-    display: flex;
-    gap: 0.5rem;
-    margin-bottom: var(--spacing-3);
-  }
-  .filters button {
-    border: 1px solid var(--color-border);
-    background: var(--color-surface);
-    border-radius: var(--radius-full);
-    padding: 0.35rem 0.75rem;
-    cursor: pointer;
-    color: var(--color-text-secondary);
-  }
-  .filters button.active,
-  .filters button:hover {
-    border-color: var(--color-primary-300);
-    color: var(--color-primary-700);
-    background: var(--color-primary-50);
-  }
-  .clear-filter {
-    margin-left: 0.5rem;
   }
 
   .list {


### PR DESCRIPTION
## Summary

Closes #121

- Agrega campo `estado:` al meta-lenguaje con aliases (pendientes, reconocidas, esperadas, pend, rec, esp, etc.)
- Crea componente `UnifiedSearchBox` con hints contextuales que aparecen al escribir prefijos de campo
- Reemplaza botones de estado separados y CategoryPills con búsqueda unificada
- Simplifica `isVisible()` para usar solo searchFilters (single source of truth)
- La URL ahora refleja todos los filtros via query string (`?q=estado:pendientes emisor:coto`)

### Espacio recuperado
~100px verticales (de ~160px a ~60px para la sección de filtros)

### Hints contextuales
Cuando escribís un prefijo de campo como `estado:`, aparecen sugerencias:
- **estado:** → Pendientes, Reconocidas, Esperadas
- **emisor:** → Lista de emisores existentes
- **categoria:** → Categorías + "Sin categoría"  
- **tipo:** → FACA, FACB, FACC, NCA, etc.

Navegación con teclado: ↑↓ Tab Enter Esc

## Test plan

- [ ] Escribir `estado:pendientes` filtra correctamente
- [ ] Escribir `emisor:coto` filtra por emisor
- [ ] Combinar filtros funciona: `estado:pendientes emisor:coto`
- [ ] Hints aparecen al escribir `estado:`, `emisor:`, etc.
- [ ] Tab/Enter selecciona hint
- [ ] URL se actualiza con el query
- [ ] Refresh mantiene el filtro
- [ ] "Limpiar filtros" resetea todo

🤖 Generated with [Claude Code](https://claude.ai/claude-code)