### PR TITLE
fix(search): eliminate filter flicker on page load

### DIFF
--- a/client/src/lib/components/UnifiedSearchBox.svelte
+++ b/client/src/lib/components/UnifiedSearchBox.svelte
@@ -35,21 +35,34 @@
   let parsedResult = $state<ParseResult>({ filters: [], errors: [] });
   let inputRef = $state<HTMLInputElement | null>(null);
   let isFocused = $state(false);
+  let isInitialized = $state(false);
 
   // Detectar si estamos escribiendo un campo con hints
   let activeHintField = $derived(detectActiveHintField(value));
   let hints = $derived(generateHints(activeHintField, categories, emitters));
   let selectedHintIndex = $state(0);
 
-  // Debounce de parsing (300ms)
+  // Debounce de parsing para typing (150ms)
   const debouncedParse = debounce((query: string) => {
     parsedResult = parseSearchQuery(query);
     onfilter(parsedResult.filters);
-  }, 300);
+  }, 150);
 
-  // Efecto que dispara el parsing cuando cambia el valor
+  // Parseo inicial SÍNCRONO (sin debounce) para evitar flicker al cargar con URL
+  $effect.pre(() => {
+    if (!isInitialized && value) {
+      parsedResult = parseSearchQuery(value);
+      onfilter(parsedResult.filters);
+    }
+  });
+
+  // Efecto que dispara el parsing cuando cambia el valor (con debounce para typing)
   $effect(() => {
-    debouncedParse(value);
+    if (isInitialized) {
+      debouncedParse(value);
+    } else {
+      isInitialized = true;
+    }
   });
 
   // Reset selected hint when hints change


### PR DESCRIPTION
## Summary
- Fixes filter flicker when loading `/comprobantes?q=...` with URL parameters
- Parses filters synchronously on mount using `$effect.pre()`
- Uses debounce (reduced from 300ms to 150ms) only for user typing

## Test plan
- [x] Open `/comprobantes?q=estado:pendientes` - should show filtered results immediately without flicker
- [x] Open `/comprobantes?q=estado:reconocidas` - same behavior
- [x] Type in the search box - debounce should still work for typing
- [x] URL should update correctly when typing

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)