### PR TITLE
refactor: implement dependency injection with constructor injection (#113)

### DIFF
--- a/client/src/routes/api/comprobantes/+server.ts
+++ b/client/src/routes/api/comprobantes/+server.ts
@@ -1,8 +1,8 @@
 import { json } from '@sveltejs/kit';
-import { ComprobanteService } from '@server/services/comprobante.service';
+import { createComprobanteService } from '@server/factories';
 
 export async function GET() {
-  const service = new ComprobanteService();
+  const service = createComprobanteService();
   const comprobantes = await service.listAll();
   return json({ count: comprobantes.length, comprobantes });
 }

--- a/client/src/routes/api/expected-invoices/+server.ts
+++ b/client/src/routes/api/expected-invoices/+server.ts
@@ -4,17 +4,14 @@
 
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import {
-  ExpectedInvoiceRepository,
-  type ExpectedInvoiceStatus,
-} from '@server/database/repositories/expected-invoice.js';
-import { ExcelImportService } from '@server/services/excel-import.service.js';
+import { type ExpectedInvoiceStatus } from '@server/database/repositories/expected-invoice.js';
+import { getExpectedInvoiceRepository, createExcelImportService } from '@server/factories';
 
 export const GET: RequestHandler = async ({ url }) => {
   console.info('\n📋 [API] GET /api/expected-invoices');
 
   try {
-    const repo = new ExpectedInvoiceRepository();
+    const repo = getExpectedInvoiceRepository();
 
     // Parsear query params
     const status = url.searchParams.get('status');
@@ -97,7 +94,7 @@ export const POST: RequestHandler = async ({ request }) => {
     const { action, batchId } = await request.json();
 
     if (action === 'getBatchStats' && batchId) {
-      const service = new ExcelImportService();
+      const service = createExcelImportService();
       const stats = service.getBatchStats(batchId);
 
       return json({
@@ -107,7 +104,7 @@ export const POST: RequestHandler = async ({ request }) => {
     }
 
     if (action === 'listBatches') {
-      const service = new ExcelImportService();
+      const service = createExcelImportService();
       const batches = service.listBatches();
 
       return json({

--- a/client/src/routes/api/expected-invoices/import/+server.ts
+++ b/client/src/routes/api/expected-invoices/import/+server.ts
@@ -4,7 +4,7 @@
 
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { ExcelImportService } from '@server/services/excel-import.service.js';
+import { createExcelImportService } from '@server/factories';
 import { writeFile, mkdir } from 'fs/promises';
 import path from 'path';
 import { existsSync } from 'fs';
@@ -62,7 +62,7 @@ export const POST: RequestHandler = async ({ request }) => {
     console.info(`   💾 Archivo guardado: ${filePath}`);
 
     // Importar con el servicio
-    const importService = new ExcelImportService();
+    const importService = createExcelImportService();
     const result = await importService.importFromFile(filePath);
 
     console.info(`   ✅ Importación completada:`);

--- a/client/src/routes/api/invoices/export/+server.ts
+++ b/client/src/routes/api/invoices/export/+server.ts
@@ -4,9 +4,11 @@
 
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { FileExportService } from '@server/services/file-export.service.js';
-import { InvoiceRepository } from '@server/database/repositories/invoice.js';
-import { FileRepository } from '@server/database/repositories/file.js';
+import {
+  createFileExportService,
+  getInvoiceRepository,
+  getFileRepository,
+} from '@server/factories';
 import { join } from 'path';
 
 const DATA_DIR = join(process.cwd(), '..', 'data');
@@ -24,9 +26,9 @@ export const POST: RequestHandler = async ({ request }) => {
       );
     }
 
-    const invoiceRepo = new InvoiceRepository();
-    const fileRepo = new FileRepository();
-    const exportService = new FileExportService(OUTPUT_DIR);
+    const invoiceRepo = getInvoiceRepository();
+    const fileRepo = getFileRepository();
+    const exportService = createFileExportService(OUTPUT_DIR);
 
     const invoices = (await Promise.all(invoiceIds.map((id) => invoiceRepo.findById(id)))).filter(
       (inv) => inv !== null

--- a/client/src/routes/api/invoices/from-file/[fileId]/+server.ts
+++ b/client/src/routes/api/invoices/from-file/[fileId]/+server.ts
@@ -6,10 +6,10 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import {
-  InvoiceCreationService,
   type InvoiceCreationData,
   type InvoiceCreationOptions,
 } from '@server/services/invoice-creation.service';
+import { createInvoiceCreationService } from '@server/factories';
 
 export const POST: RequestHandler = async ({ params, request }) => {
   try {
@@ -42,7 +42,7 @@ export const POST: RequestHandler = async ({ params, request }) => {
 
     const options: InvoiceCreationOptions = { source, expectedId };
 
-    const service = new InvoiceCreationService();
+    const service = createInvoiceCreationService();
     const result = await service.createFromFile(fileId, data, options);
 
     if (!result.success) {

--- a/client/src/routes/api/invoices/process/+server.ts
+++ b/client/src/routes/api/invoices/process/+server.ts
@@ -6,9 +6,11 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { join } from 'path';
-import { InvoiceProcessingService } from '@server/services/invoice-processing.service.js';
-import { FileRepository } from '@server/database/repositories/file.js';
-import { FileExtractionRepository } from '@server/database/repositories/file-extraction.js';
+import {
+  createInvoiceProcessingService,
+  getFileRepository,
+  getFileExtractionRepository,
+} from '@server/factories';
 
 export const POST: RequestHandler = async ({ request }) => {
   console.info('⚙️  [PROCESS] Iniciando procesamiento de facturas...');
@@ -37,9 +39,9 @@ export const POST: RequestHandler = async ({ request }) => {
       return json({ success: false, error: 'Se requiere un array de fileIds' }, { status: 400 });
     }
 
-    const fileRepo = new FileRepository();
-    const extractionRepo = new FileExtractionRepository();
-    const processingService = new InvoiceProcessingService();
+    const fileRepo = getFileRepository();
+    const extractionRepo = getFileExtractionRepository();
+    const processingService = createInvoiceProcessingService();
 
     // Cargar files desde BD
     const filesPromises = fileIds.map((id) => fileRepo.findById(id));

--- a/client/src/routes/api/invoices/upload/+server.ts
+++ b/client/src/routes/api/invoices/upload/+server.ts
@@ -8,11 +8,13 @@ import type { RequestHandler } from './$types';
 import { writeFile, mkdir, unlink } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
-import { FileRepository } from '@server/database/repositories/file.js';
-import { FileExtractionRepository } from '@server/database/repositories/file-extraction.js';
-import { InvoiceRepository } from '@server/database/repositories/invoice.js';
+import {
+  getFileRepository,
+  getFileExtractionRepository,
+  getInvoiceRepository,
+  createInvoiceProcessingService,
+} from '@server/factories';
 import { calculateFileHash } from '@server/utils/file-hash.js';
-import { InvoiceProcessingService } from '@server/services/invoice-processing.service.js';
 
 const UPLOAD_DIR = join(process.cwd(), '..', 'data', 'input');
 
@@ -39,10 +41,10 @@ export const POST: RequestHandler = async ({ request }) => {
 
     const uploadedFiles = [];
     const errors = [];
-    const fileRepo = new FileRepository();
-    const extractionRepo = new FileExtractionRepository();
-    const invoiceRepo = new InvoiceRepository();
-    const processingService = new InvoiceProcessingService();
+    const fileRepo = getFileRepository();
+    const extractionRepo = getFileExtractionRepository();
+    const invoiceRepo = getInvoiceRepository();
+    const processingService = createInvoiceProcessingService();
 
     for (const file of files) {
       console.info(`📄 [UPLOAD] Procesando: ${file.name} (${(file.size / 1024).toFixed(1)}KB)`);

--- a/server/database/repositories/category.ts
+++ b/server/database/repositories/category.ts
@@ -6,7 +6,16 @@ import { eq } from 'drizzle-orm';
 import { db } from '../db';
 import { categories, type Category, type NewCategory } from '../schema';
 
-export class CategoryRepository {
+/**
+ * Interface for CategoryRepository - enables dependency injection and testing
+ */
+export interface ICategoryRepository {
+  findById(id: number): Promise<Category | undefined>;
+  findByKey(key: string): Promise<Category | undefined>;
+  findAllActive(): Promise<Category[]>;
+}
+
+export class CategoryRepository implements ICategoryRepository {
   /**
    * Obtiene todas las categorías activas
    */

--- a/server/database/repositories/emitter.ts
+++ b/server/database/repositories/emitter.ts
@@ -8,7 +8,23 @@ import { db } from '../db.js';
 import { emisores, type Emisor, type NewEmisor } from '../schema.js';
 import type { Emitter } from '@shared/types';
 
-export class EmitterRepository {
+/**
+ * Interface for EmitterRepository - enables dependency injection and testing
+ */
+export interface IEmitterRepository {
+  findByCUIT(cuit: string): Emitter | null;
+  create(data: {
+    cuit: string;
+    name: string;
+    legalName?: string;
+    aliases?: string[];
+    personType?: 'FISICA' | 'JURIDICA';
+  }): Emitter;
+  list(filters?: { active?: boolean }): Emitter[];
+  updateName(cuit: string, name: string, legalName?: string): void;
+}
+
+export class EmitterRepository implements IEmitterRepository {
   /**
    * Mapea un Emisor de Drizzle a la interfaz Emitter del sistema
    */

--- a/server/database/repositories/expected-invoice.ts
+++ b/server/database/repositories/expected-invoice.ts
@@ -46,7 +46,42 @@ export interface ImportBatch {
   notes: string | null;
 }
 
-export class ExpectedInvoiceRepository {
+/**
+ * Interface for ExpectedInvoiceRepository - enables dependency injection and testing
+ */
+export interface IExpectedInvoiceRepository {
+  findById(id: number): Promise<ExpectedInvoice | null>;
+  findExactMatch(
+    cuit: string,
+    type: number | null,
+    pointOfSale: number,
+    invoiceNumber: number
+  ): Promise<ExpectedInvoice | null>;
+  findPartialMatches(criteria: {
+    cuit?: string;
+    cuitPartial?: string;
+    invoiceType?: number | null;
+    pointOfSale?: number;
+    invoiceNumber?: number;
+    issueDate?: string;
+    total?: number;
+    limit?: number;
+  }): Promise<
+    Array<
+      ExpectedInvoice & { matchScore: number; matchedFields: string[]; totalFieldsCompared: number }
+    >
+  >;
+  listWithFiles(filters?: {
+    status?: ExpectedInvoiceStatus | ExpectedInvoiceStatus[];
+    batchId?: number;
+    cuit?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<ExpectedInvoice[]>;
+  updateStatus(id: number, status: ExpectedInvoiceStatus): void;
+}
+
+export class ExpectedInvoiceRepository implements IExpectedInvoiceRepository {
   private mapDrizzleToExpectedInvoice(row: DrizzelExpectedInvoice | undefined): ExpectedInvoice {
     if (!row) {
       throw new Error('Cannot map undefined row to ExpectedInvoice');

--- a/server/database/repositories/invoice.ts
+++ b/server/database/repositories/invoice.ts
@@ -8,6 +8,70 @@ import { facturas, type Factura } from '../schema';
 import type { InvoiceType, Currency, ExtractionMethod } from '@shared/types';
 
 /**
+ * Interface for InvoiceRepository - enables dependency injection and testing
+ */
+export interface IInvoiceRepository {
+  create(data: {
+    emitterCuit: string;
+    templateUsedId?: number;
+    issueDate: Date | string;
+    invoiceType: InvoiceType;
+    pointOfSale: number;
+    invoiceNumber: number;
+    total?: number;
+    currency?: Currency;
+    fileId: number;
+    fileType: 'PDF_DIGITAL' | 'PDF_IMAGEN' | 'IMAGEN';
+    extractionMethod: ExtractionMethod;
+    extractionConfidence?: number;
+    requiresReview?: boolean;
+    expectedInvoiceId?: number;
+    categoryId?: number;
+  }): Promise<Invoice>;
+  findById(id: number): Promise<Invoice | null>;
+  findByFileId(fileId: number): Promise<Invoice[]>;
+  findByInvoiceNumber(
+    emitterCuit: string,
+    type: InvoiceType,
+    pointOfSale: number,
+    number: number
+  ): Promise<Invoice | null>;
+  list(filters?: {
+    emitterCuit?: string;
+    dateFrom?: Date;
+    dateTo?: Date;
+    minAmount?: number;
+    maxAmount?: number;
+    invoiceType?: InvoiceType;
+    requiresReview?: boolean;
+    limit?: number;
+    offset?: number;
+  }): Promise<Invoice[]>;
+  update(
+    id: number,
+    data: Partial<{
+      emisorCuit: string;
+      tipoComprobante: InvoiceType;
+      puntoVenta: number;
+      numeroComprobante: number;
+      comprobanteCompleto: string;
+      total: number;
+      fechaEmision: string;
+      categoryId: number | null;
+      expectedInvoiceId: number | null;
+    }>
+  ): Promise<Invoice | null>;
+  deleteWithUnlink(
+    id: number
+  ): Promise<
+    | { success: true; unlinkedExpected?: number; unlinkedFile?: number }
+    | { success: false; error: string }
+  >;
+  /** @deprecated Use FileRepository.updatePath() instead */
+  updateProcessedFile(id: number, processedFile: string, finalizedFile?: string): void;
+}
+
+/**
  * Invoice interface - rutas de archivo se obtienen via fileId -> files table
  * Las columnas archivo_procesado y finalized_file fueron eliminadas en migración 0014
  *
@@ -43,7 +107,7 @@ export interface Invoice {
   categoryId?: number;
 }
 
-export class InvoiceRepository {
+export class InvoiceRepository implements IInvoiceRepository {
   private mapDrizzleToInvoice(row: Factura): Invoice {
     return {
       id: row.id,

--- a/server/factories/index.ts
+++ b/server/factories/index.ts
@@ -1,0 +1,139 @@
+/**
+ * Factory functions for creating services with dependencies.
+ * Use these factories in production code to create properly-wired service instances.
+ * For testing, instantiate services directly with mock dependencies.
+ */
+
+// Repositories
+import { FileRepository } from '../database/repositories/file';
+import { FileExtractionRepository } from '../database/repositories/file-extraction';
+import { InvoiceRepository } from '../database/repositories/invoice';
+import { ExpectedInvoiceRepository } from '../database/repositories/expected-invoice';
+import { EmitterRepository } from '../database/repositories/emitter';
+import { CategoryRepository } from '../database/repositories/category';
+
+// Services
+import { InvoiceCreationService } from '../services/invoice-creation.service';
+import { InvoiceFileService } from '../services/invoice-file.service';
+import { ComprobanteService } from '../services/comprobante.service';
+import { InvoiceProcessingService } from '../services/invoice-processing.service';
+import { ExcelImportService } from '../services/excel-import.service';
+import { FileExportService } from '../services/file-export.service';
+
+// Extractors
+import { PDFExtractor } from '../extractors/pdf-extractor';
+import { OCRExtractor } from '../extractors/ocr-extractor';
+
+/**
+ * Singleton instances of repositories.
+ * Repositories are stateless so sharing instances is safe and reduces memory.
+ */
+let _fileRepo: FileRepository | null = null;
+let _extractionRepo: FileExtractionRepository | null = null;
+let _invoiceRepo: InvoiceRepository | null = null;
+let _expectedRepo: ExpectedInvoiceRepository | null = null;
+let _emitterRepo: EmitterRepository | null = null;
+let _categoryRepo: CategoryRepository | null = null;
+
+export function getFileRepository(): FileRepository {
+  if (!_fileRepo) _fileRepo = new FileRepository();
+  return _fileRepo;
+}
+
+export function getFileExtractionRepository(): FileExtractionRepository {
+  if (!_extractionRepo) _extractionRepo = new FileExtractionRepository();
+  return _extractionRepo;
+}
+
+export function getInvoiceRepository(): InvoiceRepository {
+  if (!_invoiceRepo) _invoiceRepo = new InvoiceRepository();
+  return _invoiceRepo;
+}
+
+export function getExpectedInvoiceRepository(): ExpectedInvoiceRepository {
+  if (!_expectedRepo) _expectedRepo = new ExpectedInvoiceRepository();
+  return _expectedRepo;
+}
+
+export function getEmitterRepository(): EmitterRepository {
+  if (!_emitterRepo) _emitterRepo = new EmitterRepository();
+  return _emitterRepo;
+}
+
+export function getCategoryRepository(): CategoryRepository {
+  if (!_categoryRepo) _categoryRepo = new CategoryRepository();
+  return _categoryRepo;
+}
+
+/**
+ * Factory for InvoiceFileService
+ */
+export function createInvoiceFileService(): InvoiceFileService {
+  return new InvoiceFileService(getFileRepository(), getCategoryRepository());
+}
+
+/**
+ * Factory for InvoiceCreationService
+ */
+export function createInvoiceCreationService(): InvoiceCreationService {
+  return new InvoiceCreationService(
+    getFileRepository(),
+    getFileExtractionRepository(),
+    getInvoiceRepository(),
+    getExpectedInvoiceRepository(),
+    getEmitterRepository(),
+    getCategoryRepository(),
+    createInvoiceFileService()
+  );
+}
+
+/**
+ * Factory for ComprobanteService
+ */
+export function createComprobanteService(): ComprobanteService {
+  return new ComprobanteService(
+    getInvoiceRepository(),
+    getExpectedInvoiceRepository(),
+    getFileRepository(),
+    getFileExtractionRepository(),
+    getEmitterRepository()
+  );
+}
+
+/**
+ * Factory for InvoiceProcessingService
+ */
+export function createInvoiceProcessingService(): InvoiceProcessingService {
+  return new InvoiceProcessingService(
+    new PDFExtractor(),
+    new OCRExtractor(),
+    getEmitterRepository(),
+    getExpectedInvoiceRepository()
+  );
+}
+
+/**
+ * Factory for ExcelImportService
+ */
+export function createExcelImportService(): ExcelImportService {
+  return new ExcelImportService(getExpectedInvoiceRepository(), getEmitterRepository());
+}
+
+/**
+ * Factory for FileExportService
+ */
+export function createFileExportService(outputDir?: string): FileExportService {
+  return new FileExportService(outputDir, getInvoiceRepository(), getEmitterRepository());
+}
+
+/**
+ * Reset all singleton instances (useful for testing)
+ */
+export function resetSingletons(): void {
+  _fileRepo = null;
+  _extractionRepo = null;
+  _invoiceRepo = null;
+  _expectedRepo = null;
+  _emitterRepo = null;
+  _categoryRepo = null;
+}

--- a/server/services/comprobante.service.ts
+++ b/server/services/comprobante.service.ts
@@ -4,27 +4,39 @@
  * facturas finales, expected invoices, y archivos subidos.
  */
 
-import { ExpectedInvoiceRepository } from '../database/repositories/expected-invoice';
-import { InvoiceRepository } from '../database/repositories/invoice';
-import { FileRepository } from '../database/repositories/file';
-import { FileExtractionRepository } from '../database/repositories/file-extraction';
-import { EmitterRepository } from '../database/repositories/emitter';
+import {
+  ExpectedInvoiceRepository,
+  type IExpectedInvoiceRepository,
+} from '../database/repositories/expected-invoice';
+import { InvoiceRepository, type IInvoiceRepository } from '../database/repositories/invoice';
+import { FileRepository, type IFileRepository } from '../database/repositories/file';
+import {
+  FileExtractionRepository,
+  type IFileExtractionRepository,
+} from '../database/repositories/file-extraction';
+import { EmitterRepository, type IEmitterRepository } from '../database/repositories/emitter';
 import { normalizeToISO } from '../utils/dates';
 import type { Final, Expected, FileData, Comprobante } from '@shared/types';
 
 export class ComprobanteService {
-  private invoiceRepo: InvoiceRepository;
-  private expectedRepo: ExpectedInvoiceRepository;
-  private fileRepo: FileRepository;
-  private extractionRepo: FileExtractionRepository;
-  private emitterRepo: EmitterRepository;
+  private invoiceRepo: IInvoiceRepository;
+  private expectedRepo: IExpectedInvoiceRepository;
+  private fileRepo: IFileRepository;
+  private extractionRepo: IFileExtractionRepository;
+  private emitterRepo: IEmitterRepository;
 
-  constructor() {
-    this.invoiceRepo = new InvoiceRepository();
-    this.expectedRepo = new ExpectedInvoiceRepository();
-    this.fileRepo = new FileRepository();
-    this.extractionRepo = new FileExtractionRepository();
-    this.emitterRepo = new EmitterRepository();
+  constructor(
+    invoiceRepo?: IInvoiceRepository,
+    expectedRepo?: IExpectedInvoiceRepository,
+    fileRepo?: IFileRepository,
+    extractionRepo?: IFileExtractionRepository,
+    emitterRepo?: IEmitterRepository
+  ) {
+    this.invoiceRepo = invoiceRepo ?? new InvoiceRepository();
+    this.expectedRepo = expectedRepo ?? new ExpectedInvoiceRepository();
+    this.fileRepo = fileRepo ?? new FileRepository();
+    this.extractionRepo = extractionRepo ?? new FileExtractionRepository();
+    this.emitterRepo = emitterRepo ?? new EmitterRepository();
   }
 
   /**

--- a/server/services/excel-import.service.ts
+++ b/server/services/excel-import.service.ts
@@ -5,7 +5,7 @@
 import ExcelJS from 'exceljs';
 import { normalizeCUIT, validateCUIT } from '@shared/validators/cuit';
 import { ExpectedInvoiceRepository } from '../database/repositories/expected-invoice.js';
-import { EmitterRepository } from '../database/repositories/emitter.js';
+import { EmitterRepository, type IEmitterRepository } from '../database/repositories/emitter.js';
 import { normalizeEmitterName } from '../utils/emitter-name-normalizer.js';
 import path from 'path';
 
@@ -97,11 +97,11 @@ export type ExcelFormat = 'simple' | 'arca-full';
  */
 export class ExcelImportService {
   private repo: ExpectedInvoiceRepository;
-  private emitterRepo: EmitterRepository;
+  private emitterRepo: IEmitterRepository;
 
-  constructor() {
-    this.repo = new ExpectedInvoiceRepository();
-    this.emitterRepo = new EmitterRepository();
+  constructor(repo?: ExpectedInvoiceRepository, emitterRepo?: IEmitterRepository) {
+    this.repo = repo ?? new ExpectedInvoiceRepository();
+    this.emitterRepo = emitterRepo ?? new EmitterRepository();
   }
 
   /**

--- a/server/services/file-export.service.ts
+++ b/server/services/file-export.service.ts
@@ -9,8 +9,8 @@
 import { copyFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import type { Invoice } from '@shared/types';
-import { InvoiceRepository } from '../database/repositories/invoice.js';
-import { EmitterRepository } from '../database/repositories/emitter.js';
+import { InvoiceRepository, type IInvoiceRepository } from '../database/repositories/invoice.js';
+import { EmitterRepository, type IEmitterRepository } from '../database/repositories/emitter.js';
 import { generateSubdirectory, generateProcessedFilename } from '../utils/file-naming.js';
 
 export interface ExportOptions {
@@ -27,13 +27,17 @@ export interface ExportResult {
 }
 
 export class FileExportService {
-  private invoiceRepo: InvoiceRepository;
-  private emitterRepo: EmitterRepository;
+  private invoiceRepo: IInvoiceRepository;
+  private emitterRepo: IEmitterRepository;
   private defaultOutputDir: string;
 
-  constructor(outputDir?: string) {
-    this.invoiceRepo = new InvoiceRepository();
-    this.emitterRepo = new EmitterRepository();
+  constructor(
+    outputDir?: string,
+    invoiceRepo?: IInvoiceRepository,
+    emitterRepo?: IEmitterRepository
+  ) {
+    this.invoiceRepo = invoiceRepo ?? new InvoiceRepository();
+    this.emitterRepo = emitterRepo ?? new EmitterRepository();
     this.defaultOutputDir = outputDir || './data/finalized';
   }
 

--- a/server/services/invoice-creation.service.ts
+++ b/server/services/invoice-creation.service.ts
@@ -4,12 +4,18 @@
  * Extraído del endpoint POST /api/invoices/from-file/[fileId].
  */
 
-import { FileRepository } from '../database/repositories/file';
-import { FileExtractionRepository } from '../database/repositories/file-extraction';
-import { InvoiceRepository } from '../database/repositories/invoice';
-import { ExpectedInvoiceRepository } from '../database/repositories/expected-invoice';
-import { EmitterRepository } from '../database/repositories/emitter';
-import { CategoryRepository } from '../database/repositories/category';
+import { FileRepository, type IFileRepository } from '../database/repositories/file';
+import {
+  FileExtractionRepository,
+  type IFileExtractionRepository,
+} from '../database/repositories/file-extraction';
+import { InvoiceRepository, type IInvoiceRepository } from '../database/repositories/invoice';
+import {
+  ExpectedInvoiceRepository,
+  type IExpectedInvoiceRepository,
+} from '../database/repositories/expected-invoice';
+import { EmitterRepository, type IEmitterRepository } from '../database/repositories/emitter';
+import { CategoryRepository, type ICategoryRepository } from '../database/repositories/category';
 import { InvoiceFileService } from './invoice-file.service';
 import { validateCUIT, normalizeCUIT, formatCUIT } from '@shared/validators/cuit';
 
@@ -43,22 +49,30 @@ export interface InvoiceCreationResult {
 }
 
 export class InvoiceCreationService {
-  private fileRepo: FileRepository;
-  private extractionRepo: FileExtractionRepository;
-  private invoiceRepo: InvoiceRepository;
-  private expectedRepo: ExpectedInvoiceRepository;
-  private emitterRepo: EmitterRepository;
-  private categoryRepo: CategoryRepository;
+  private fileRepo: IFileRepository;
+  private extractionRepo: IFileExtractionRepository;
+  private invoiceRepo: IInvoiceRepository;
+  private expectedRepo: IExpectedInvoiceRepository;
+  private emitterRepo: IEmitterRepository;
+  private categoryRepo: ICategoryRepository;
   private fileService: InvoiceFileService;
 
-  constructor() {
-    this.fileRepo = new FileRepository();
-    this.extractionRepo = new FileExtractionRepository();
-    this.invoiceRepo = new InvoiceRepository();
-    this.expectedRepo = new ExpectedInvoiceRepository();
-    this.emitterRepo = new EmitterRepository();
-    this.categoryRepo = new CategoryRepository();
-    this.fileService = new InvoiceFileService(this.fileRepo, this.categoryRepo);
+  constructor(
+    fileRepo?: IFileRepository,
+    extractionRepo?: IFileExtractionRepository,
+    invoiceRepo?: IInvoiceRepository,
+    expectedRepo?: IExpectedInvoiceRepository,
+    emitterRepo?: IEmitterRepository,
+    categoryRepo?: ICategoryRepository,
+    fileService?: InvoiceFileService
+  ) {
+    this.fileRepo = fileRepo ?? new FileRepository();
+    this.extractionRepo = extractionRepo ?? new FileExtractionRepository();
+    this.invoiceRepo = invoiceRepo ?? new InvoiceRepository();
+    this.expectedRepo = expectedRepo ?? new ExpectedInvoiceRepository();
+    this.emitterRepo = emitterRepo ?? new EmitterRepository();
+    this.categoryRepo = categoryRepo ?? new CategoryRepository();
+    this.fileService = fileService ?? new InvoiceFileService(this.fileRepo, this.categoryRepo);
   }
 
   /**

--- a/server/services/invoice-file.service.ts
+++ b/server/services/invoice-file.service.ts
@@ -17,7 +17,7 @@ import { existsSync, readdirSync, statSync } from 'fs';
 import { copyFile, mkdir, rename } from 'fs/promises';
 import { join } from 'path';
 import { FileRepository, type IFileRepository } from '../database/repositories/file.js';
-import { CategoryRepository } from '../database/repositories/category.js';
+import { CategoryRepository, type ICategoryRepository } from '../database/repositories/category.js';
 import { generateProcessedFilename, generateSubdirectory } from '../utils/file-naming.js';
 import type { Emitter, InvoiceType } from '@shared/types';
 
@@ -62,9 +62,9 @@ export interface InvoiceUpdateFields {
 
 export class InvoiceFileService {
   private fileRepo: IFileRepository;
-  private categoryRepo: CategoryRepository;
+  private categoryRepo: ICategoryRepository;
 
-  constructor(fileRepo?: IFileRepository, categoryRepo?: CategoryRepository) {
+  constructor(fileRepo?: IFileRepository, categoryRepo?: ICategoryRepository) {
     this.fileRepo = fileRepo ?? new FileRepository();
     this.categoryRepo = categoryRepo ?? new CategoryRepository();
   }

--- a/server/services/invoice-processing.service.ts
+++ b/server/services/invoice-processing.service.ts
@@ -12,9 +12,10 @@
 import { PDFExtractor } from '../extractors/pdf-extractor.js';
 import { OCRExtractor } from '../extractors/ocr-extractor.js';
 import { validateCUIT, normalizeCUIT, getPersonType } from '@shared/validators/cuit';
-import { EmitterRepository } from '../database/repositories/emitter.js';
+import { EmitterRepository, type IEmitterRepository } from '../database/repositories/emitter.js';
 import {
   ExpectedInvoiceRepository,
+  type IExpectedInvoiceRepository,
   type ExpectedInvoice,
 } from '../database/repositories/expected-invoice.js';
 import { format } from 'date-fns';
@@ -49,14 +50,19 @@ export interface ProcessingResult {
 export class InvoiceProcessingService {
   private pdfExtractor: PDFExtractor;
   private ocrExtractor: OCRExtractor;
-  private emitterRepo: EmitterRepository;
-  private expectedInvoiceRepo: ExpectedInvoiceRepository;
+  private emitterRepo: IEmitterRepository;
+  private expectedInvoiceRepo: IExpectedInvoiceRepository;
 
-  constructor() {
-    this.pdfExtractor = new PDFExtractor();
-    this.ocrExtractor = new OCRExtractor();
-    this.emitterRepo = new EmitterRepository();
-    this.expectedInvoiceRepo = new ExpectedInvoiceRepository();
+  constructor(
+    pdfExtractor?: PDFExtractor,
+    ocrExtractor?: OCRExtractor,
+    emitterRepo?: IEmitterRepository,
+    expectedInvoiceRepo?: IExpectedInvoiceRepository
+  ) {
+    this.pdfExtractor = pdfExtractor ?? new PDFExtractor();
+    this.ocrExtractor = ocrExtractor ?? new OCRExtractor();
+    this.emitterRepo = emitterRepo ?? new EmitterRepository();
+    this.expectedInvoiceRepo = expectedInvoiceRepo ?? new ExpectedInvoiceRepository();
   }
 
   /**


### PR DESCRIPTION
## Summary
- Agrega interfaces (`IFileRepository`, `IInvoiceRepository`, etc.) a todos los repositorios
- Refactoriza servicios para aceptar dependencias via constructor con fallbacks opcionales
- Crea `server/factories/index.ts` con factory functions para uso en producción
- Actualiza endpoints API para usar factories en lugar de instanciación directa

## Beneficios
- Los servicios pueden testearse con mocks
- Las dependencias son explícitas y documentadas
- Repositorios singleton reducen uso de memoria
- Sin overhead de framework (TypeScript puro)

## Test plan
- [x] Verificar que `npm run check` pasa
- [x] Verificar que la app funciona normalmente (upload, process, create invoice)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)