### PR TITLE
fix(qr): try multiple PDF render scales to handle dense QR codes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,33 @@ npm run db:migrate   # Migraciones
 npm run db:studio    # GUI Drizzle
 ```
 
+## Workflow Obligatorio con Git
+
+### Flujo de trabajo
+**Siempre** seguir este orden, sin excepciones:
+
+1. `git checkout main && git pull`
+2. `git checkout -b <tipo>/<descripcion-corta>` (ej: `fix/qr-pdf-scale`, `feat/nueva-feature`)
+3. Implementar en commits incrementales (un commit por paso lógico)
+4. Push del branch: `git push -u origin <branch>`
+5. Crear PR con `gh pr create`
+6. Completar el Post-PR Checklist
+
+**Nunca** commitear directo a `main`. **Nunca** empezar a escribir código sin crear el branch primero.
+
+### Modelo de trabajo con agentes
+Este proyecto usa un esquema de dos niveles:
+
+- **Opus** (planificación): diseña el plan, define el approach, verifica el resultado final (QA)
+- **Sonnet/Haiku** (ejecución): implementa el plan
+
+Cuando Claude recibe una tarea de implementación no trivial, debe:
+1. Pensar el plan antes de tocar código
+2. Ejecutar en pasos verificables
+3. Dejar el resultado en un estado que Opus pueda revisar (branch pusheado, PR abierto)
+
+El objetivo es reducir interacción innecesaria: el usuario no debería tener que recordar el flujo ni hacer de QA manual.
+
 ## Post-PR Checklist
 
 After creating or merging a PR, always:

--- a/server/extractors/qr-extractor.ts
+++ b/server/extractors/qr-extractor.ts
@@ -116,23 +116,35 @@ export class QRExtractor {
 
     const ext = extname(filePath).toLowerCase();
 
-    // PDFs: iterar todas las páginas buscando QR AFIP/ARCA
+    // PDFs: iterar todas las páginas buscando QR AFIP/ARCA.
+    // Se prueban múltiples scales porque jsQR falla cuando el QR es demasiado grande
+    // (scale alto → módulos muy grandes → jsQR no decodifica). Scale 3 es el punto dulce
+    // para QR de alta densidad (ARCA con JSON largo); scale 5 sigue siendo útil para
+    // documentos escaneados donde el QR puede ser pequeño.
     if (ext === '.pdf') {
-      try {
-        const pages = this.pdfToImages(filePath);
-        for await (const { pageNumber, buffer } of pages) {
-          console.info(`   🔍 Escaneando página ${pageNumber}...`);
-          const result = await this.detectQRInImage(buffer);
-          if (result.found && result.rawData && this.isAFIPUrl(result.rawData)) {
-            console.info(`   ✅ QR AFIP/ARCA encontrado en página ${pageNumber}`);
-            return result;
+      // jsQR falla cuando el QR tiene módulos demasiado grandes (scale alto + QR denso).
+      // Scale 3 es el punto óptimo para QR de alta densidad (ARCA con JSON largo).
+      // Scale 5 como fallback para documentos escaneados con QR pequeño.
+      const scales = [3.0, 5.0, 2.0];
+      for (const scale of scales) {
+        try {
+          console.info(`   🔄 Intentando con scale ${scale}...`);
+          const pages = this.pdfToImages(filePath, scale);
+          for await (const { pageNumber, buffer } of pages) {
+            console.info(`   🔍 Escaneando página ${pageNumber} (scale ${scale})...`);
+            const result = await this.detectQRInImage(buffer);
+            if (result.found && result.rawData && this.isAFIPUrl(result.rawData)) {
+              console.info(
+                `   ✅ QR AFIP/ARCA encontrado en página ${pageNumber} (scale ${scale})`
+              );
+              return result;
+            }
           }
+        } catch (error) {
+          console.error(`   ❌ Error procesando páginas del PDF (scale ${scale}):`, error);
         }
-        return { found: false, error: 'No se encontró QR de AFIP/ARCA en ninguna página del PDF' };
-      } catch (error) {
-        console.error(`   ❌ Error procesando páginas del PDF:`, error);
-        return { found: false, error: 'Error convirtiendo PDF a imágenes' };
       }
+      return { found: false, error: 'No se encontró QR de AFIP/ARCA en ninguna página del PDF' };
     }
 
     // HEIC/HEIF: convertir y escanear


### PR DESCRIPTION
## Problema

`jsQR` fallaba decodificando QR codes de alta densidad (ARCA con JSON largo) cuando el PDF se renderizaba a `scale: 5.0`. A ese scale, cada módulo del QR ocupa demasiados píxeles y jsQR no puede interpretarlo, aunque sí detecta los finder patterns (devuelve string vacío `""`).

Reproducible con cualquier factura digital de ARCA — por ejemplo `file:159` fallaba con scale 5 y funcionaba perfecto con scale 3.

## Solución

Probar múltiples scales en orden `[3.0, 5.0, 2.0]` para PDFs:

- **3.0**: punto óptimo para facturas digitales con QR de alta densidad
- **5.0**: fallback para documentos escaneados donde el QR puede ser pequeño
- **2.0**: último recurso

Se retorna al primer scale que encuentre un QR AFIP/ARCA válido.

## Test

- `file:159` (ARCA FAC A digital): ahora se decodifica correctamente con scale 3 ✅
- `file:146` (ticket Coto escaneado): sigue fallando correctamente — el QR de ARCA está físicamente degradado por el fondo impreso, no hay solución de software ✅

## Checklist

- [x] 121 tests unitarios pasando
- [x] CLAUDE.md actualizado con workflow obligatorio de git y modelo de agentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)