### PR TITLE
feat: balance group sub-rows as full comprobantes

### DIFF
--- a/client/src/lib/services/ComprobanteService.ts
+++ b/client/src/lib/services/ComprobanteService.ts
@@ -3,6 +3,8 @@
  * Centralizes all API calls for invoice viewing/editing.
  */
 
+import type { Comprobante } from '$lib/types/comprobante';
+
 export type ExtractionMethod = 'ocr' | 'pdf_text' | 'qr';
 
 export interface ExpectedInvoiceSummary {
@@ -275,6 +277,31 @@ class ComprobanteService {
   // =============================================================================
   // Balance Group Operations
   // =============================================================================
+
+  /**
+   * Get balance group members as full Comprobante objects.
+   * Used for rendering sub-rows with editable category, status, navigation.
+   */
+  async getBalanceGroupAsComprobantes(
+    expectedId: number
+  ): Promise<ApiResult<{ members: Comprobante[]; total: number; isBalanced: boolean }>> {
+    try {
+      const response = await fetch(
+        `/api/expected-invoices/${expectedId}/balance?format=comprobantes`
+      );
+      if (response.ok) {
+        const data = await response.json();
+        return {
+          success: true,
+          data: { members: data.members, total: data.total, isBalanced: data.isBalanced },
+        };
+      }
+      const err = await response.json();
+      return { success: false, error: err.error || 'Error al obtener grupo de balance' };
+    } catch {
+      return { success: false, error: 'Error al obtener grupo de balance' };
+    }
+  }
 
   /**
    * Get the balance group for an expected invoice

--- a/client/src/routes/api/comprobantes/+server.ts
+++ b/client/src/routes/api/comprobantes/+server.ts
@@ -3,6 +3,6 @@ import { createComprobanteService } from '@server/factories';
 
 export async function GET() {
   const service = createComprobanteService();
-  const comprobantes = await service.listAll();
+  const { comprobantes } = await service.listAll();
   return json({ count: comprobantes.length, comprobantes });
 }

--- a/client/src/routes/api/expected-invoices/[id]/balance/+server.ts
+++ b/client/src/routes/api/expected-invoices/[id]/balance/+server.ts
@@ -10,6 +10,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { ExpectedInvoiceRepository } from '@server/database/repositories/expected-invoice';
+import { createComprobanteService } from '@server/factories';
 import {
   BalanceGroupAddSchema,
   BalanceGroupSetPrincipalSchema,
@@ -60,7 +61,7 @@ async function buildBalanceGroupResponse(
  * Get the balance group for this expected invoice.
  * Returns the group if it exists, or null if the invoice has no group.
  */
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, url }) => {
   const id = parseInt(params.id, 10);
   if (isNaN(id)) {
     return json({ error: 'ID inválido' }, { status: 400 });
@@ -79,6 +80,18 @@ export const GET: RequestHandler = async ({ params }) => {
     const hasGroup = await repo.hasBalanceGroup(principalId);
     if (!hasGroup) {
       return json({ group: null });
+    }
+
+    // Return full Comprobante objects when requested
+    const format = url.searchParams.get('format');
+    if (format === 'comprobantes') {
+      const service = createComprobanteService();
+      const result = await service.listAll({ balanceGroupOf: principalId });
+      return json({
+        members: result.comprobantes,
+        total: result.groupTotal,
+        isBalanced: result.groupIsBalanced,
+      });
     }
 
     const response = await buildBalanceGroupResponse(principalId);

--- a/client/src/routes/comprobantes/+page.svelte
+++ b/client/src/routes/comprobantes/+page.svelte
@@ -23,7 +23,7 @@
   import { createFilterMatcher, type FilterNode } from '$lib/search';
   import { navigationStore } from '$lib/stores/navigation';
   import { comprobanteService } from '$lib/services/ComprobanteService';
-  import { Copy, CopyCheck } from '$lib/components/icons';
+  import { Copy, CopyCheck, ChevronRight, ChevronDown } from '$lib/components/icons';
   import {
     generateFilenameForFile,
     generateFilenameForSheet,
@@ -220,6 +220,102 @@
     document.addEventListener('click', handler);
     return () => document.removeEventListener('click', handler);
   });
+
+  // --- Helpers for copy and balance group ---
+  function getStatusEmoji(comp: Comprobante): string {
+    const parts: string[] = [];
+    if (comp.file || comp.final?.fileId) parts.push('📄');
+    if (comp.final) parts.push('✅');
+    if (comp.expected || comp.final?.expectedInvoiceId) parts.push('📋');
+    if (comp.expected?.isBalanceGroupPrincipal) parts.push('⚖️');
+    return parts.join('') || '—';
+  }
+
+  function getCategoryName(comp: Comprobante): string {
+    const catId = comp.final?.categoryId ?? comp.expected?.categoryId ?? comp.file?.categoryId;
+    if (catId == null) return '—';
+    const cat = categories.find((c) => c.id === catId);
+    return cat?.description ?? '—';
+  }
+
+  // --- Balance group expand/collapse ---
+  interface ExpandedGroup {
+    members: Comprobante[];
+    total: number;
+    isBalanced: boolean;
+  }
+  let expandedGroups = $state<Map<number, ExpandedGroup>>(new Map());
+  let loadingGroups = $state<Set<number>>(new Set());
+
+  async function toggleBalanceGroup(expectedId: number) {
+    if (expandedGroups.has(expectedId)) {
+      const next = new Map(expandedGroups);
+      next.delete(expectedId);
+      expandedGroups = next;
+      return;
+    }
+
+    loadingGroups = new Set([...loadingGroups, expectedId]);
+    const result = await comprobanteService.getBalanceGroupAsComprobantes(expectedId);
+    const nextLoading = new Set(loadingGroups);
+    nextLoading.delete(expectedId);
+    loadingGroups = nextLoading;
+
+    if (result.success && result.data) {
+      const next = new Map(expandedGroups);
+      next.set(expectedId, {
+        members: result.data.members,
+        total: result.data.total,
+        isBalanced: result.data.isBalanced,
+      });
+      expandedGroups = next;
+    } else {
+      toast.error(result.error || 'Error al cargar grupo de balance');
+    }
+  }
+
+  const CREDIT_NOTE_TYPES = new Set([3, 8, 13, 21, 53]);
+
+  function isCreditNote(invoiceType: number | null): boolean {
+    return invoiceType != null && CREDIT_NOTE_TYPES.has(invoiceType);
+  }
+
+  function formatSignedTotal(total: number | null | undefined, invoiceType: number | null): string {
+    if (total == null) return '—';
+    const isCredit = isCreditNote(invoiceType);
+    return isCredit ? `-${formatCurrency(total)}` : formatCurrency(total);
+  }
+
+  function getExpandedMemberRows(comp: Comprobante) {
+    const expectedId = comp.expected?.id;
+    if (expectedId == null || !expandedGroups.has(expectedId)) return [];
+    const group = expandedGroups.get(expectedId)!;
+    const rows = group.members.map((member) => {
+      const invoiceType = member.expected?.invoiceType ?? member.final?.invoiceType ?? null;
+      const total =
+        member.expected?.total ?? member.final?.total ?? member.file?.extractedTotal ?? null;
+      return {
+        date: member.effectiveDate ? formatDateShort(member.effectiveDate) : '—',
+        emitter: '',
+        cuit: '',
+        compName: `└ ${formatComprobante(member)}`,
+        total: formatSignedTotal(total, invoiceType),
+        category: getCategoryName(member),
+        status: getStatusEmoji(member),
+      };
+    });
+    // Add total row
+    rows.push({
+      date: '',
+      emitter: '',
+      cuit: '',
+      compName: '',
+      total: `= ${formatCurrency(Math.abs(group.total))}`,
+      category: '',
+      status: '',
+    });
+    return rows;
+  }
 
   function isVisible(c: Comprobante): boolean {
     // Todos los filtros se aplican via meta-lenguaje (AND lógico)
@@ -558,9 +654,29 @@
         comp.expected?.cuit ||
         comp.file?.extractedCuit
       )}
+      {@const isBalancePrincipal = comp.expected?.isBalanceGroupPrincipal ?? false}
+      {@const expectedId = comp.expected?.id}
+      {@const isExpanded = expectedId != null && expandedGroups.has(expectedId)}
+      {@const isLoading = expectedId != null && loadingGroups.has(expectedId)}
       <div class="row">
         <!-- Columna 1: Comprobante/Archivo -->
         <span class="col-cmp" class:col-cmp-extended={!hasEmitter}>
+          {#if isBalancePrincipal && expectedId != null}
+            <button
+              class="expand-btn"
+              onclick={() => toggleBalanceGroup(expectedId)}
+              title={isExpanded ? 'Colapsar grupo' : 'Expandir grupo de balance'}
+              type="button"
+            >
+              {#if isLoading}
+                <span class="spinner"></span>
+              {:else if isExpanded}
+                <ChevronDown size={14} />
+              {:else}
+                <ChevronRight size={14} />
+              {/if}
+            </button>
+          {/if}
           {formatComprobante(comp)}
         </span>
 
@@ -658,6 +774,76 @@
           <Button size="sm" onclick={() => navigateToDetail(comp.id)}>Ver</Button>
         </span>
       </div>
+      {#if isExpanded && expectedId != null}
+        {@const group = expandedGroups.get(expectedId)}
+        {@const members = group?.members ?? []}
+        {#each members as member, idx}
+          {@const isLast = idx === members.length - 1}
+          {@const memberInvoiceType =
+            member.expected?.invoiceType ?? member.final?.invoiceType ?? null}
+          <div class="row sub-row">
+            <span class="col-cmp">
+              <span class="sub-row-indent">{isLast ? '└' : '├'}</span>
+              {formatComprobante(member)}
+            </span>
+            <span class="col-emisor-cuit"></span>
+            <span class="col-date">
+              {member.effectiveDate ? formatDateShort(member.effectiveDate) : '—'}
+            </span>
+            <span
+              class="col-total align-right"
+              class:total-credit={isCreditNote(memberInvoiceType)}
+            >
+              {formatSignedTotal(
+                member.expected?.total ??
+                  member.final?.total ??
+                  member.file?.extractedTotal ??
+                  null,
+                memberInvoiceType
+              )}
+            </span>
+            <span class="col-category">
+              {#if member.expected}
+                <CategorySelect
+                  {categories}
+                  value={member.expected.categoryId ?? null}
+                  onchange={(id: number | null) =>
+                    member.expected && updateExpectedCategory(member.expected.id, id)}
+                />
+              {:else}
+                —
+              {/if}
+            </span>
+            <span class="col-type-status">
+              <CompletenessIndicator comprobante={member} />
+            </span>
+            <span class="col-hash">—</span>
+            <span class="col-actions">
+              <Button size="sm" onclick={() => navigateToDetail(member.id)}>Ver</Button>
+            </span>
+          </div>
+        {/each}
+        {#if group}
+          <div class="row sub-row sub-row-total">
+            <span class="col-cmp"></span>
+            <span class="col-emisor-cuit"></span>
+            <span class="col-date"></span>
+            <span class="col-total align-right">
+              <span
+                class="balance-total"
+                class:balanced={group.isBalanced}
+                class:unbalanced={!group.isBalanced}
+              >
+                = {formatCurrency(Math.abs(group.total))}
+              </span>
+            </span>
+            <span class="col-category"></span>
+            <span class="col-type-status"></span>
+            <span class="col-hash"></span>
+            <span class="col-actions"></span>
+          </div>
+        {/if}
+      {/if}
     {/each}
   </section>
 </div>
@@ -787,7 +973,7 @@
   .row {
     display: grid;
     /* Comprobante | Emisor (flexible) | Fecha | Total | Categoría | Estado | Hash | Acción */
-    grid-template-columns: 180px minmax(200px, 1fr) 85px 110px 150px 90px 70px 100px;
+    grid-template-columns: 220px minmax(200px, 1fr) 85px 110px 150px 90px 70px 100px;
     gap: var(--spacing-2);
     padding: var(--spacing-2) var(--spacing-3);
     align-items: center;
@@ -809,6 +995,74 @@
   }
   .row:hover {
     background: var(--color-surface-alt);
+  }
+
+  .row.sub-row {
+    background: var(--color-primary-50);
+    border-top: 1px solid var(--color-primary-100);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+  }
+  .row.sub-row:last-of-type {
+    border-bottom: 1px solid var(--color-primary-100);
+  }
+
+  .sub-row-indent {
+    color: var(--color-primary-300);
+    margin-right: var(--spacing-1);
+    font-family: monospace;
+  }
+
+  .total-credit {
+    color: var(--color-error);
+  }
+
+  .balance-total {
+    font-weight: var(--font-weight-semibold);
+    font-size: var(--font-size-sm);
+  }
+  .balance-total.balanced {
+    color: var(--color-success-600);
+  }
+  .balance-total.unbalanced {
+    color: var(--color-warning-600);
+  }
+
+  .sub-row-total {
+    border-top: 2px solid var(--color-primary-200);
+  }
+
+  .expand-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    padding: 0;
+    margin-right: var(--spacing-1);
+    cursor: pointer;
+    color: var(--color-primary-600);
+    border-radius: var(--radius-sm);
+    width: 18px;
+    height: 18px;
+  }
+  .expand-btn:hover {
+    background: var(--color-primary-100);
+  }
+
+  .spinner {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border: 2px solid var(--color-primary-200);
+    border-top-color: var(--color-primary-600);
+    border-radius: 50%;
+    animation: spin 0.6s linear infinite;
+  }
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
   }
 
   .tag {

--- a/server/database/repositories/expected-invoice.ts
+++ b/server/database/repositories/expected-invoice.ts
@@ -112,6 +112,17 @@ export interface IExpectedInvoiceRepository {
   }): Promise<ExpectedInvoice[]>;
   refreshStatus(id: number): Promise<ExpectedInvoiceStatus>;
   getPrincipalIds(): Promise<Set<number>>;
+  getBalanceGroup(id: number): Promise<ExpectedInvoice[]>;
+  calculateGroupBalance(principalId: number): Promise<{
+    total: number;
+    members: Array<{
+      id: number;
+      total: number | null;
+      invoiceType: number | null;
+      signedTotal: number;
+    }>;
+    isBalanced: boolean;
+  }>;
 }
 
 export class ExpectedInvoiceRepository implements IExpectedInvoiceRepository {

--- a/server/services/comprobante.service.ts
+++ b/server/services/comprobante.service.ts
@@ -42,8 +42,19 @@ export class ComprobanteService {
   /**
    * Construye la lista completa de comprobantes consolidados.
    * Une facturas, expected invoices y archivos sin procesar en un solo DTO.
+   *
+   * When `balanceGroupOf` is provided, returns only the secundarios of that
+   * balance group as full Comprobante objects (with group total/balance info).
    */
-  async listAll(): Promise<Comprobante[]> {
+  async listAll(options?: { balanceGroupOf?: number }): Promise<{
+    comprobantes: Comprobante[];
+    groupTotal?: number;
+    groupIsBalanced?: boolean;
+  }> {
+    if (options?.balanceGroupOf != null) {
+      return this.listBalanceGroupMembers(options.balanceGroupOf);
+    }
+
     const invoices = await this.invoiceRepo.list();
     const expectedInvoices = await this.expectedRepo.listWithFiles({
       status: ['pending', 'balanced'],
@@ -138,7 +149,73 @@ export class ComprobanteService {
       return 0;
     });
 
-    return comprobantes;
+    return { comprobantes };
+  }
+
+  /**
+   * Builds Comprobante[] for the secundarios of a balance group.
+   * Used to render sub-rows as full comprobantes with editable category, status, etc.
+   */
+  private async listBalanceGroupMembers(principalId: number): Promise<{
+    comprobantes: Comprobante[];
+    groupTotal?: number;
+    groupIsBalanced?: boolean;
+  }> {
+    const group = await this.expectedRepo.getBalanceGroup(principalId);
+    if (group.length === 0) return { comprobantes: [] };
+
+    // Only secundarios (those pointing to the principal)
+    const secundarios = group.filter((inv) => inv.balancedWithId !== null);
+    if (secundarios.length === 0) return { comprobantes: [] };
+
+    // Build emitter cache for secundarios
+    const uniqueCuits = new Set(
+      secundarios.map((inv) => inv.cuit).filter((c): c is string => Boolean(c))
+    );
+    const emitterCache = new Map<string, string | null>();
+    for (const cuit of uniqueCuits) {
+      const emitter = this.emitterRepo.findByCUIT(cuit);
+      emitterCache.set(cuit, emitter?.displayName || null);
+    }
+
+    // Build Comprobante[] for each secundario
+    const comprobantes: Comprobante[] = secundarios.map((inv) => {
+      const expected: Expected = {
+        source: 'expected' as const,
+        id: inv.id,
+        cuit: inv.cuit,
+        emitterName: emitterCache.get(inv.cuit) || inv.emitterName,
+        issueDate: inv.issueDate,
+        invoiceType: inv.invoiceType,
+        pointOfSale: inv.pointOfSale,
+        invoiceNumber: inv.invoiceNumber,
+        total: inv.total,
+        status: inv.status,
+        categoryId: inv.categoryId ?? null,
+        balancedWithId: inv.balancedWithId ?? null,
+        isBalanceGroupPrincipal: false,
+      };
+
+      return {
+        id: `expected:${inv.id}`,
+        kind: 'expected' as const,
+        final: null,
+        expected,
+        file: null,
+        emitterCuit: inv.cuit,
+        emitterName: emitterCache.get(inv.cuit) || inv.emitterName,
+        effectiveDate: inv.issueDate,
+      };
+    });
+
+    // Calculate balance
+    const balance = await this.expectedRepo.calculateGroupBalance(principalId);
+
+    return {
+      comprobantes,
+      groupTotal: balance.total,
+      groupIsBalanced: balance.isBalanced,
+    };
   }
 
   private buildUploadedFiles(): FileData[] {


### PR DESCRIPTION
## Summary
- Las sub-filas de balance groups en la lista de comprobantes ahora son comprobantes completos
- Cada secundario muestra: comprobante formateado, fecha, total con signo, categoria editable, indicadores de estado, y boton "Ver" para navegar al detalle
- Fila de total del grupo con estilo balanced/unbalanced
- Backend: `ComprobanteService.listAll({ balanceGroupOf })` devuelve secundarios como `Comprobante[]`
- Endpoint: `GET /api/expected-invoices/:id/balance?format=comprobantes` retorna miembros como objetos Comprobante completos

## Test plan
- [ ] Abrir lista de comprobantes con al menos un balance group (principal con icono Scale)
- [ ] Click en el chevron del principal: debe expandir mostrando los secundarios como filas completas
- [ ] Verificar que cada sub-fila tiene: nombre de comprobante, fecha, total con signo (negativo para NCR), categoria editable, indicadores de estado
- [ ] Cambiar categoria de un secundario desde la sub-fila: debe actualizarse correctamente
- [ ] Click en "Ver" de un secundario: debe navegar al detalle del comprobante
- [ ] Verificar fila de total: muestra `= $X` con estilo verde (balanced) o naranja (unbalanced)
- [ ] Click de nuevo en el chevron: debe colapsar el grupo
- [ ] Verificar que el endpoint existente sin `?format=comprobantes` sigue funcionando igual

🤖 Generated with [Claude Code](https://claude.com/claude-code)