### PR TITLE
feat(qr): migrate from jsQR to zxing-wasm

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -121,7 +121,7 @@ Plan de trabajo organizado en fases progresivas, alternando features con tech de
 - [x] #156 - HEIC file preview broken (Content-Type hardcoded a application/pdf) (PR #157)
 - [x] Fix QR serviciosweb.afip.gob.ar URL pattern (PR #165)
 - [x] Fix QR JSON malformado de ARCA (consumidor final sin DNI) + debug toolkit (PR #172)
-- [ ] #173 - QR extraction: estrategia para tickets térmicos degradados (paste manual + expand PDF_TEXT + eval zxing-wasm)
+- [ ] #173 - QR extraction: paste manual fallback + expand PDF_TEXT para CAE (zxing-wasm ya migrado, PR #174)
 - [ ] #54 - Simplificar algoritmo matching
 - [ ] #93 - Testing extracción docs confidenciales
 - [ ] #129 - Importar desglose impositivo ARCA

--- a/package-lock.json
+++ b/package-lock.json
@@ -2750,6 +2750,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/emscripten": {
+			"version": "1.41.5",
+			"resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+			"integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5674,12 +5680,6 @@
 				"npm": ">=6"
 			}
 		},
-		"node_modules/jsqr": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
-			"integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
-			"license": "Apache-2.0"
-		},
 		"node_modules/jszip": {
 			"version": "3.10.1",
 			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -7664,6 +7664,18 @@
 			"integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
 			"license": "MIT"
 		},
+		"node_modules/tagged-tag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+			"integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/tar-fs": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -8491,6 +8503,21 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/type-fest": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+			"integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+			"license": "(MIT OR CC0-1.0)",
+			"dependencies": {
+				"tagged-tag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/typescript": {
@@ -9570,6 +9597,19 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
+		"node_modules/zxing-wasm": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.0.2.tgz",
+			"integrity": "sha512-2YMAriaYHX9wrBY2k7H0epSo+dyCaCZg/vOtt+nEDXM9ul480gkXz/9SkwpOeHcD2H5qqDG8lWDSBwpTcZpa6w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/emscripten": "^1.41.5",
+				"type-fest": "^5.5.0"
+			},
+			"peerDependencies": {
+				"@types/emscripten": ">=1.39.6"
+			}
+		},
 		"server": {
 			"name": "procesador-facturas-server",
 			"version": "0.2.0",
@@ -9579,14 +9619,14 @@
 				"drizzle-orm": "1.0.0-beta.15-859cf75",
 				"exceljs": "^4.4.0",
 				"heic-convert": "^2.1.0",
-				"jsqr": "^1.4.0",
 				"pdf-lib": "^1.17.1",
 				"pdf-parse": "^1.1.1",
 				"pdf-to-img": "^5.0.0",
 				"sharp": "^0.34.5",
 				"tesseract.js": "^7.0.0",
 				"yaml": "^2.8.1",
-				"zod": "^4.0.0"
+				"zod": "^4.0.0",
+				"zxing-wasm": "3.0.2"
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.16.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"debug:qr:scales": "tsx scripts/debug/qr/scales.ts",
 		"debug:qr:preprocess": "tsx scripts/debug/qr/preprocess.ts",
 		"debug:qr:crop-arca": "tsx scripts/debug/qr/crop-arca.ts",
+		"debug:qr:benchmark": "tsx scripts/debug/qr/benchmark.ts",
 		"lint": "npm run lint --workspaces --if-present",
 		"format": "npm run format --workspaces --if-present",
 		"format:check": "npm run format:check --workspaces --if-present",

--- a/scripts/debug/qr/README.md
+++ b/scripts/debug/qr/README.md
@@ -2,42 +2,29 @@
 
 Scripts reutilizables para diagnosticar problemas de extracción de QR. Todos son pequeños y autocontenidos — usalos cuando un comprobante no reconoce el QR correctamente y querés entender por qué antes de tocar el extractor.
 
-## Cuándo usar cada uno
+## Scripts activos (usan zxing-wasm)
 
-El flujo típico de diagnóstico va de lo más alto a lo más bajo nivel:
-
-| Script | Cuándo | Qué muestra |
+| Script | Cuándo | npm script |
 |---|---|---|
-| `extract.ts` | Primer paso siempre. Corre el pipeline completo igual que el server. | Resultado final del `QRExtractor` (campos extraídos, confianza, errores). |
-| `raw.ts` | `extract.ts` falló o devolvió datos raros. Querés ver el payload crudo del QR. | URL decodificada, JSON en texto plano (antes del parseo), y si `JSON.parse` falla. |
-| `scales.ts` | Sospechás que el scale de render del PDF no es el óptimo. | Matriz de detección probando scales 2→6 × tamaños de ventana. Útil para ver si el QR es decodificable a algún scale y cuál. |
-| `preprocess.ts` | jsQR ve el QR pero no lo decodifica (imagen degradada). | Prueba variantes de grayscale, normalise, threshold, sharpen, blur, etc. sobre el tercio inferior de la página. Guarda recortes en `/tmp/qr-bottom-*.png` para inspección visual. |
-| `crop-arca.ts` | Tickets térmicos Coto/supermercados con dos QRs (Coto + ARCA) donde el de ARCA está degradado. | Combinación masiva: 4 scales × 4 regiones × 13 variantes de preprocesamiento. Guarda recortes en `/tmp/arca-crop-*.png`. |
+| `extract.ts` | Primer paso siempre. Corre el pipeline completo igual que el server. | `npm run debug:qr` |
+| `raw.ts` | `extract.ts` falló o devolvió datos raros. Querés ver el payload crudo del QR. | `npm run debug:qr:raw` |
+| `benchmark.ts` | Comparar jsQR vs zxing-wasm lado a lado (requiere `npm install jsqr` manual). | `npm run debug:qr:benchmark` |
 
-## Comandos
+## Scripts legacy (requieren jsQR, pre-migración)
 
-Todos corren vía npm scripts desde la raíz del repo:
+Los siguientes scripts fueron creados para diagnosticar limitaciones de jsQR. Se conservan como documentación del proceso que motivó la migración a zxing-wasm. Para ejecutarlos, instalar jsQR manualmente: `npm install jsqr -w server`.
 
-```bash
-npm run debug:qr           -- data/input/mi-factura.pdf
-npm run debug:qr:raw       -- data/input/mi-factura.pdf
-npm run debug:qr:scales    -- data/input/mi-factura.pdf
-npm run debug:qr:preprocess -- data/input/mi-factura.pdf
-npm run debug:qr:crop-arca -- data/input/mi-factura.pdf
-```
-
-Tip: agregá `2>/dev/null` al final si te molesta el ruido de pdfjs en stderr.
+| Script | Propósito original |
+|---|---|
+| `scales.ts` | Probar múltiples render scales (jsQR fallaba con scale alto). |
+| `preprocess.ts` | Probar preprocesamiento (grayscale, threshold, etc.) para QRs degradados. |
+| `crop-arca.ts` | Recorte exhaustivo para tickets Coto con dual QR. |
+| `hand-crop.ts` | Recorte manual a ojo para verificar que ni un crop humano salva a jsQR. |
 
 ## Workflow sugerido
 
 1. **Reproducí el problema**: `npm run debug:qr -- <archivo>`.
-   - Si devuelve éxito → el problema no está en el extractor, está en el pipeline upstream (cómo se guarda, cuándo se corre, etc.).
+   - Si devuelve éxito → el problema no está en el extractor, está en el pipeline upstream.
    - Si devuelve error → leé el mensaje.
-2. **Si el error es "JSON inválido"**: corré `raw.ts` para ver el payload exacto. Los QR de ARCA a veces tienen JSON malformado (`"nroDocRec":,`) — el extractor ya lo maneja, pero si aparece una variante nueva conviene capturarla.
-3. **Si el error es "No se encontró QR"**: corré `scales.ts`. Si algún scale detecta el QR, actualizamos el orden en el extractor. Si ninguno lo detecta → el problema es de imagen, pasá al punto 4.
-4. **Si ningún scale funciona**: corré `preprocess.ts` (general) o `crop-arca.ts` (específico para tickets Coto). Si ALGUNA variante lo decodifica, la incorporamos al extractor. Si NINGUNA lo decodifica → estamos en el límite de jsQR, y la solución es fallback de paste manual o migración a zxing-wasm.
-
-## Limitaciones conocidas
-
-- **jsQR falla con finder patterns degradados** (tickets térmicos muy desgastados). Ningún preprocesamiento lo resuelve — es limitación estructural del decoder. En esos casos, usar el fallback de paste manual en la UI.
-- **Los scripts no usan exactamente la misma ventana deslizante que el extractor real** — usan variantes simplificadas para diagnóstico. Si querés reproducir al 100% lo que hace el server, usá `extract.ts`.
+2. **Si el error es "JSON inválido"**: corré `npm run debug:qr:raw -- <archivo>` para ver el payload exacto. Los QR de ARCA a veces tienen JSON malformado (`"nroDocRec":,`) — el extractor ya lo maneja con `parseAFIPJson`, pero si aparece una variante nueva conviene capturarla.
+3. **Si el error es "No se encontró QR"**: con zxing-wasm esto es raro. Si ocurre, el QR está tan destruido que ni ZXing con tryHarder lo recupera. Solución: fallback de paste manual en la UI (ver issue #173).

--- a/scripts/debug/qr/benchmark.ts
+++ b/scripts/debug/qr/benchmark.ts
@@ -1,0 +1,146 @@
+/**
+ * Benchmark: jsQR vs zxing-wasm contra un set de archivos de test.
+ * Compara ambos decoders lado a lado para validar la migración.
+ *
+ * Uso:
+ *   npx tsx scripts/debug/qr/benchmark.ts <archivo1> [archivo2] [archivo3] ...
+ *   npx tsx scripts/debug/qr/benchmark.ts data/input/invoice-*.pdf
+ *
+ * Ejemplo con los dos casos conocidos:
+ *   npx tsx scripts/debug/qr/benchmark.ts \
+ *     data/input/invoice-2000015306120516.pdf \
+ *     "data/input/2026-04-07 23.02 - Adobe Scan.pdf"
+ */
+import jsQR from "jsqr";
+import sharp from "sharp";
+import { pdf } from "pdf-to-img";
+import { readFileSync } from "fs";
+import { readBarcodes } from "zxing-wasm/reader";
+import { basename } from "path";
+
+const AFIP_PREFIXES = [
+  "https://www.afip.gob.ar/fe/qr/",
+  "https://servicioscf.afip.gob.ar/publico/comprobantes/",
+  "https://serviciosweb.afip.gob.ar/genericos/comprobantes/",
+  "https://www.arca.gob.ar/fe/qr/",
+];
+
+function isAFIP(url: string): boolean {
+  return AFIP_PREFIXES.some((p) => url.startsWith(p));
+}
+
+interface DecoderResult {
+  found: boolean;
+  isAFIP: boolean;
+  url?: string;
+  timeMs: number;
+}
+
+async function getPageBuffer(filePath: string, scale: number): Promise<Buffer> {
+  const pdfBuf = readFileSync(filePath);
+  const doc = await pdf(pdfBuf, { scale });
+  for await (const page of doc) {
+    return page as Buffer;
+  }
+  throw new Error("PDF sin páginas");
+}
+
+async function tryJsQR(
+  pixels: Uint8ClampedArray,
+  width: number,
+  height: number,
+): Promise<DecoderResult> {
+  const t0 = performance.now();
+  const qr = jsQR(pixels, width, height, { inversionAttempts: "attemptBoth" });
+  const timeMs = performance.now() - t0;
+  if (qr && qr.data) {
+    return { found: true, isAFIP: isAFIP(qr.data), url: qr.data, timeMs };
+  }
+  return { found: false, isAFIP: false, timeMs };
+}
+
+async function tryZXing(
+  pixels: Uint8ClampedArray,
+  width: number,
+  height: number,
+): Promise<DecoderResult> {
+  const imageData = { data: pixels, width, height };
+  const t0 = performance.now();
+  const results = await readBarcodes(imageData, {
+    formats: ["QRCode"],
+    tryHarder: true,
+    maxNumberOfSymbols: 5,
+  });
+  const timeMs = performance.now() - t0;
+
+  // Find AFIP QR among results
+  for (const r of results) {
+    if (r.text && isAFIP(r.text)) {
+      return { found: true, isAFIP: true, url: r.text, timeMs };
+    }
+  }
+  // If no AFIP QR, report first non-empty result
+  if (results.length > 0 && results[0].text) {
+    return {
+      found: true,
+      isAFIP: false,
+      url: results[0].text,
+      timeMs,
+    };
+  }
+  return { found: false, isAFIP: false, timeMs };
+}
+
+async function benchmarkFile(filePath: string): Promise<void> {
+  const name = basename(filePath);
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(`${name}`);
+  console.log("=".repeat(60));
+
+  for (const scale of [3.0, 5.0]) {
+    const pageBuf = await getPageBuffer(filePath, scale);
+    const { data, info } = await sharp(pageBuf)
+      .ensureAlpha()
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+    const pixels = new Uint8ClampedArray(data);
+
+    console.log(`\n  scale ${scale} (${info.width}x${info.height}):`);
+
+    const jsqr = await tryJsQR(pixels, info.width, info.height);
+    const zxing = await tryZXing(pixels, info.width, info.height);
+
+    const fmtResult = (r: DecoderResult) => {
+      if (!r.found) return `❌ no QR (${r.timeMs.toFixed(0)}ms)`;
+      const tag = r.isAFIP ? "✅ AFIP" : "⚠️  otro";
+      return `${tag} (${r.timeMs.toFixed(0)}ms) → ${(r.url || "").substring(0, 50)}...`;
+    };
+
+    console.log(`    jsQR:   ${fmtResult(jsqr)}`);
+    console.log(`    zxing:  ${fmtResult(zxing)}`);
+  }
+}
+
+async function main() {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.error(
+      "Uso: npx tsx scripts/debug/qr/benchmark.ts <archivo1> [archivo2] ...",
+    );
+    process.exit(1);
+  }
+
+  console.log(`Benchmark jsQR vs zxing-wasm — ${files.length} archivo(s)`);
+
+  for (const f of files) {
+    await benchmarkFile(f);
+  }
+
+  console.log("\n" + "=".repeat(60));
+  console.log("Benchmark completo.");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/debug/qr/hand-crop.ts
+++ b/scripts/debug/qr/hand-crop.ts
@@ -1,0 +1,131 @@
+/**
+ * Recorte a mano del QR de ARCA sobre un crop ya existente.
+ * Simula lo que haría un humano con una herramienta de captura: recortar
+ * solo el bounding box del QR, con un margen mínimo, y pasárselo a jsQR
+ * con preprocesamiento agresivo.
+ *
+ * Se usa para responder la pregunta: "si recorto el QR a mano, ¿jsQR lo lee?"
+ *
+ * Uso:
+ *   npx tsx scripts/debug/qr/hand-crop.ts <ruta-imagen> <left> <top> <width> <height>
+ */
+import jsQR from "jsqr";
+import sharp from "sharp";
+
+async function tryDecode(buf: Buffer, label: string): Promise<boolean> {
+  try {
+    const { data, info } = await sharp(buf)
+      .ensureAlpha()
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+    const qr = jsQR(new Uint8ClampedArray(data), info.width, info.height, {
+      inversionAttempts: "attemptBoth",
+    });
+    if (qr) {
+      console.log(`  ✅ ${label}: ${qr.data.substring(0, 80)}`);
+      return true;
+    }
+  } catch (e) {
+    console.log(`  ❌ ${label}: ERROR ${(e as Error).message}`);
+    return false;
+  }
+  console.log(`     ${label}: (no QR)`);
+  return false;
+}
+
+async function main() {
+  const [, , filePath, lStr, tStr, wStr, hStr] = process.argv;
+  if (!filePath || !lStr) {
+    console.error(
+      "Uso: npx tsx scripts/debug/qr/hand-crop.ts <imagen> <left> <top> <width> <height>",
+    );
+    process.exit(1);
+  }
+
+  const left = parseInt(lStr, 10);
+  const top = parseInt(tStr, 10);
+  const width = parseInt(wStr, 10);
+  const height = parseInt(hStr, 10);
+
+  console.log(`Recortando ${filePath} → (${left},${top}) ${width}x${height}`);
+  const crop = await sharp(filePath)
+    .extract({ left, top, width, height })
+    .toBuffer();
+
+  const { writeFileSync } = await import("fs");
+  writeFileSync("/tmp/hand-crop.png", crop);
+  console.log("Guardado → /tmp/hand-crop.png\n");
+
+  console.log("=== jsQR contra el recorte a mano ===");
+  await tryDecode(crop, "raw");
+
+  const gray = await sharp(crop).grayscale().toBuffer();
+  await tryDecode(gray, "grayscale");
+
+  const norm = await sharp(crop).grayscale().normalise().toBuffer();
+  await tryDecode(norm, "grayscale+normalise");
+
+  for (const t of [100, 120, 140, 160, 180]) {
+    const thr = await sharp(crop)
+      .grayscale()
+      .normalise()
+      .threshold(t)
+      .toBuffer();
+    await tryDecode(thr, `norm+thr(${t})`);
+  }
+
+  // Upscale + threshold
+  for (const mult of [1.5, 2, 3]) {
+    const m = await sharp(crop).metadata();
+    const up = await sharp(crop)
+      .resize(
+        Math.floor((m.width || 0) * mult),
+        Math.floor((m.height || 0) * mult),
+        { kernel: "lanczos3" },
+      )
+      .grayscale()
+      .normalise()
+      .threshold(140)
+      .toBuffer();
+    await tryDecode(up, `upscale ${mult}x + norm+thr(140)`);
+  }
+
+  // Downscale + threshold
+  for (const div of [2, 3, 4]) {
+    const m = await sharp(crop).metadata();
+    const down = await sharp(crop)
+      .resize(
+        Math.floor((m.width || 0) / div),
+        Math.floor((m.height || 0) / div),
+        { kernel: "lanczos3" },
+      )
+      .grayscale()
+      .normalise()
+      .threshold(140)
+      .toBuffer();
+    await tryDecode(down, `downscale 1/${div}x + norm+thr(140)`);
+  }
+
+  // Sharpen + threshold
+  const sharpThr = await sharp(crop)
+    .grayscale()
+    .sharpen()
+    .normalise()
+    .threshold(140)
+    .toBuffer();
+  await tryDecode(sharpThr, "sharpen+norm+thr(140)");
+
+  // Median + threshold
+  const med = await sharp(crop)
+    .grayscale()
+    .median(3)
+    .normalise()
+    .threshold(140)
+    .toBuffer();
+  await tryDecode(med, "median(3)+norm+thr(140)");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/debug/qr/raw.ts
+++ b/scripts/debug/qr/raw.ts
@@ -6,7 +6,7 @@
  *   npm run debug:qr:raw -- <ruta-archivo>
  *   npx tsx scripts/debug/qr/raw.ts <ruta-archivo>
  */
-import jsQR from "jsqr";
+import { readBarcodes } from "zxing-wasm/reader";
 import sharp from "sharp";
 import { readFileSync } from "fs";
 import { pdf } from "pdf-to-img";
@@ -37,30 +37,48 @@ async function main() {
     .raw()
     .toBuffer({ resolveWithObject: true });
 
-  const qr = jsQR(new Uint8ClampedArray(data), info.width, info.height);
-  if (!qr) {
+  const imageData: ImageData = {
+    data: new Uint8ClampedArray(data),
+    width: info.width,
+    height: info.height,
+    colorSpace: "srgb",
+  };
+
+  const results = await readBarcodes(imageData, {
+    formats: ["QRCode"],
+    tryHarder: true,
+    maxNumberOfSymbols: 10,
+  });
+
+  if (results.length === 0) {
     console.error("QR no detectado");
     process.exit(1);
   }
 
-  console.log("URL:", qr.data);
-  try {
-    const url = new URL(qr.data);
-    const p = url.searchParams.get("p");
-    if (p) {
-      const jsonStr = Buffer.from(p, "base64").toString("utf-8");
-      console.log("\nJSON crudo:");
-      console.log(jsonStr);
-      try {
-        const parsed = JSON.parse(jsonStr);
-        console.log("\nJSON parseado OK:");
-        console.log(parsed);
-      } catch (e) {
-        console.log("\nJSON.parse falló:", (e as Error).message);
+  console.log(`${results.length} QR(s) encontrado(s):\n`);
+
+  for (const [i, qr] of results.entries()) {
+    console.log(`--- QR #${i + 1} ---`);
+    console.log("URL:", qr.text);
+    try {
+      const url = new URL(qr.text);
+      const p = url.searchParams.get("p");
+      if (p) {
+        const jsonStr = Buffer.from(p, "base64").toString("utf-8");
+        console.log("\nJSON crudo:");
+        console.log(jsonStr);
+        try {
+          const parsed = JSON.parse(jsonStr);
+          console.log("\nJSON parseado OK:");
+          console.log(parsed);
+        } catch (e) {
+          console.log("\nJSON.parse falló:", (e as Error).message);
+        }
       }
+    } catch (e) {
+      console.log("No es URL:", (e as Error).message);
     }
-  } catch (e) {
-    console.error("No es URL válida:", (e as Error).message);
+    console.log();
   }
 }
 

--- a/server/extractors/qr-extractor.ts
+++ b/server/extractors/qr-extractor.ts
@@ -10,9 +10,13 @@
  * - https://serviciosweb.afip.gob.ar/genericos/comprobantes/cae.aspx?p={BASE64_JSON}
  *
  * Soporta: JPG, PNG, TIFF, WEBP, HEIC, PDF
+ *
+ * Usa zxing-wasm (port WASM de ZXing, el decoder de Google/Android) que maneja
+ * binarización adaptativa local, finder patterns parcialmente degradados,
+ * y Reed-Solomon completo — ideal para tickets térmicos escaneados.
  */
 
-import jsQR from 'jsqr';
+import { readBarcodes } from 'zxing-wasm/reader';
 import sharp from 'sharp';
 import { existsSync, readFileSync } from 'fs';
 import { extname } from 'path';
@@ -42,6 +46,11 @@ const SUPPORTED_IMAGE_EXTENSIONS = [
   '.heic',
   '.heif',
 ];
+
+// Scale para renderizar PDFs. ZXing no necesita multi-scale (a diferencia de jsQR)
+// porque su binarización adaptativa local maneja diferentes tamaños de módulos.
+// 3.0 es un buen balance entre resolución y performance.
+const PDF_RENDER_SCALE = 3.0;
 
 /**
  * Formatea CUIT de número a string con guiones (XX-XXXXXXXX-X)
@@ -102,32 +111,6 @@ export class QRExtractor {
   }
 
   /**
-   * Convierte PDF a imágenes (todas las páginas).
-   * Usa scale 5.0 para mejor detección de QR codes pequeños en documentos escaneados.
-   * Retorna un generador asíncrono que produce { pageNumber, buffer } por cada página.
-   */
-  private async *pdfToImages(
-    filePath: string,
-    scale = 5.0
-  ): AsyncGenerator<{ pageNumber: number; buffer: Buffer }> {
-    const pdfBuffer = readFileSync(filePath);
-    const document = await pdf(pdfBuffer, { scale });
-
-    console.info(`   🔄 PDF con ${document.length} página(s) (scale: ${scale})`);
-
-    let pageNumber = 0;
-    for await (const page of document) {
-      pageNumber++;
-      console.info(`   📄 Página ${pageNumber} convertida (${page.length} bytes)`);
-      yield { pageNumber, buffer: page };
-    }
-
-    if (pageNumber === 0) {
-      console.warn(`   ⚠️ PDF vacío o sin páginas`);
-    }
-  }
-
-  /**
    * Detecta y decodifica QR code de un archivo.
    * Para PDFs, itera todas las páginas buscando un QR de AFIP/ARCA.
    * Para imágenes, escanea directamente.
@@ -139,35 +122,35 @@ export class QRExtractor {
 
     const ext = extname(filePath).toLowerCase();
 
-    // PDFs: iterar todas las páginas buscando QR AFIP/ARCA.
-    // Se prueban múltiples scales porque jsQR falla cuando el QR es demasiado grande
-    // (scale alto → módulos muy grandes → jsQR no decodifica). Scale 3 es el punto dulce
-    // para QR de alta densidad (ARCA con JSON largo); scale 5 sigue siendo útil para
-    // documentos escaneados donde el QR puede ser pequeño.
+    // PDFs: renderizar cada página y escanear
     if (ext === '.pdf') {
-      // jsQR falla cuando el QR tiene módulos demasiado grandes (scale alto + QR denso).
-      // Scale 3 es el punto óptimo para QR de alta densidad (ARCA con JSON largo).
-      // Scale 5 como fallback para documentos escaneados con QR pequeño.
-      const scales = [3.0, 5.0, 2.0];
-      for (const scale of scales) {
-        try {
-          console.info(`   🔄 Intentando con scale ${scale}...`);
-          const pages = this.pdfToImages(filePath, scale);
-          for await (const { pageNumber, buffer } of pages) {
-            console.info(`   🔍 Escaneando página ${pageNumber} (scale ${scale})...`);
-            const result = await this.detectQRInImage(buffer);
-            if (result.found && result.rawData && this.isAFIPUrl(result.rawData)) {
-              console.info(
-                `   ✅ QR AFIP/ARCA encontrado en página ${pageNumber} (scale ${scale})`
-              );
-              return result;
-            }
+      try {
+        const pdfBuffer = readFileSync(filePath);
+        const document = await pdf(pdfBuffer, { scale: PDF_RENDER_SCALE });
+
+        console.info(`   🔄 PDF con ${document.length} página(s) (scale: ${PDF_RENDER_SCALE})`);
+
+        let pageNumber = 0;
+        for await (const page of document) {
+          pageNumber++;
+          console.info(`   📄 Página ${pageNumber} convertida (${page.length} bytes)`);
+          console.info(`   🔍 Escaneando página ${pageNumber}...`);
+
+          const result = await this.detectQRInImage(page);
+          if (result.found && result.rawData && this.isAFIPUrl(result.rawData)) {
+            console.info(`   ✅ QR AFIP/ARCA encontrado en página ${pageNumber}`);
+            return result;
           }
-        } catch (error) {
-          console.error(`   ❌ Error procesando páginas del PDF (scale ${scale}):`, error);
         }
+
+        return {
+          found: false,
+          error: 'No se encontró QR de AFIP/ARCA en ninguna página del PDF',
+        };
+      } catch (error) {
+        console.error(`   ❌ Error procesando páginas del PDF:`, error);
+        return { found: false, error: 'Error convirtiendo PDF a imágenes' };
       }
-      return { found: false, error: 'No se encontró QR de AFIP/ARCA en ninguna página del PDF' };
     }
 
     // HEIC/HEIF: convertir y escanear
@@ -177,141 +160,62 @@ export class QRExtractor {
     }
 
     // Imágenes: escanear directamente
-    return this.detectQRInImage(filePath);
+    return this.detectQRInImage(readFileSync(filePath));
   }
 
   /**
-   * Busca QR code de AFIP/ARCA en una imagen (buffer o path).
-   * Usa escaneo completo primero, luego ventana deslizante de abajo hacia arriba.
+   * Busca QR codes de AFIP/ARCA en una imagen usando zxing-wasm.
+   *
+   * ZXing maneja internamente binarización adaptativa y múltiples estrategias
+   * de detección (PURE, HARDER, HYBRID), así que no necesitamos sliding window
+   * ni preprocesamiento manual.
    */
-  private async detectQRInImage(imageSource: string | Buffer): Promise<QRDetectionResult> {
-    const metadata = await sharp(imageSource).metadata();
-    const width = metadata.width || 0;
-    const height = metadata.height || 0;
-
-    console.info(`   🔍 Buscando código QR AFIP/ARCA (${width}x${height})...`);
-
-    // Primero intentar detección directa en imagen completa
-    const fullImageResult = await this.detectQRInRegion(imageSource, 0, 0, width, height);
-    if (
-      fullImageResult.found &&
-      fullImageResult.rawData &&
-      this.isAFIPUrl(fullImageResult.rawData)
-    ) {
-      console.info(`   ✅ QR AFIP/ARCA detectado directamente`);
-      return fullImageResult;
-    }
-
-    // Si hay QR pero no es de AFIP, o no se encontró QR,
-    // usar sliding window para buscar múltiples QR codes.
-    // Multiple window sizes handle QR codes of different physical sizes
-    // (e.g. ARCA QR on receipts can be >400px at high render scales).
-    console.info(`   🔄 Usando sliding window para buscar QR AFIP/ARCA...`);
-
-    const windowConfigs = [
-      { size: 800, step: 400 },
-      { size: 600, step: 300 },
-      { size: 400, step: 200 },
-    ];
-    const foundQRs = new Map<string, { x: number; y: number }>();
-
-    for (const { size: windowSize, step } of windowConfigs) {
-      if (windowSize > width || windowSize > height) continue;
-
-      const yPositions = this.slidingPositions(height, windowSize, step);
-      const xPositions = this.slidingPositions(width, windowSize, step);
-
-      for (const y of yPositions) {
-        for (const x of xPositions) {
-          try {
-            const regionResult = await this.detectQRInRegion(
-              imageSource,
-              x,
-              y,
-              windowSize,
-              windowSize
-            );
-            if (regionResult.found && regionResult.rawData && !foundQRs.has(regionResult.rawData)) {
-              foundQRs.set(regionResult.rawData, { x, y });
-
-              // Si encontramos un QR de AFIP/ARCA, retornarlo inmediatamente
-              if (this.isAFIPUrl(regionResult.rawData)) {
-                console.info(
-                  `   ✅ QR AFIP/ARCA encontrado en región [${x},${y}] (ventana ${windowSize}px)`
-                );
-                return regionResult;
-              }
-            }
-          } catch {
-            // Ignorar errores en regiones individuales
-          }
-        }
-      }
-    }
-
-    // No se encontró QR de AFIP/ARCA
-    if (foundQRs.size > 0) {
-      const otherUrls = Array.from(foundQRs.keys()).slice(0, 2);
-      console.info(`   ⚠️ Se encontraron ${foundQRs.size} QR(s), pero ninguno de AFIP/ARCA`);
-      return {
-        found: false,
-        error: `Se encontraron ${foundQRs.size} código(s) QR pero ninguno de AFIP/ARCA. URLs: ${otherUrls.map((u) => u.substring(0, 40)).join(', ')}...`,
-      };
-    }
-
-    return { found: false, error: 'No se encontró código QR en la imagen' };
-  }
-
-  /**
-   * Generates sliding window positions from the edge inward (bottom-to-top).
-   * ARCA QR codes are almost always at the bottom of invoices, so scanning
-   * in reverse finds them faster. Always includes both edges.
-   */
-  private slidingPositions(length: number, windowSize: number, step: number): number[] {
-    const positions: number[] = [];
-    const maxPos = length - windowSize;
-    for (let pos = 0; pos <= maxPos; pos += step) {
-      positions.push(pos);
-    }
-    // Always include the edge position if the last step didn't land on it
-    const last = positions[positions.length - 1];
-    if (last === undefined || last < maxPos) {
-      positions.push(maxPos);
-    }
-    // Reverse: scan from bottom/right edge first
-    positions.reverse();
-    return positions;
-  }
-
-  /**
-   * Detecta QR code en una región específica de la imagen
-   */
-  private async detectQRInRegion(
-    imageSource: string | Buffer,
-    x: number,
-    y: number,
-    regionWidth: number,
-    regionHeight: number
-  ): Promise<QRDetectionResult> {
+  private async detectQRInImage(imageSource: Buffer): Promise<QRDetectionResult> {
     try {
       const { data, info } = await sharp(imageSource)
-        .extract({ left: x, top: y, width: regionWidth, height: regionHeight })
         .ensureAlpha()
         .raw()
         .toBuffer({ resolveWithObject: true });
 
-      const pixels = new Uint8ClampedArray(data);
+      console.info(`   🔍 Buscando código QR AFIP/ARCA (${info.width}x${info.height})...`);
 
-      const qrCode = jsQR(pixels, info.width, info.height, {
-        inversionAttempts: 'attemptBoth',
+      const imageData: ImageData = {
+        data: new Uint8ClampedArray(data),
+        width: info.width,
+        height: info.height,
+        colorSpace: 'srgb',
+      };
+
+      const results = await readBarcodes(imageData, {
+        formats: ['QRCode'],
+        tryHarder: true,
+        maxNumberOfSymbols: 5,
       });
 
-      if (qrCode) {
-        return { found: true, rawData: qrCode.data };
+      // Buscar el QR de AFIP/ARCA entre todos los detectados
+      for (const result of results) {
+        if (result.text && this.isAFIPUrl(result.text)) {
+          console.info(`   ✅ QR AFIP/ARCA detectado`);
+          return { found: true, rawData: result.text };
+        }
       }
 
-      return { found: false };
-    } catch {
+      // Reportar QRs no-AFIP encontrados (útil para diagnóstico)
+      if (results.length > 0) {
+        const otherUrls = results
+          .filter((r) => r.text)
+          .map((r) => r.text.substring(0, 40))
+          .slice(0, 2);
+        console.info(`   ⚠️ Se encontraron ${results.length} QR(s), pero ninguno de AFIP/ARCA`);
+        return {
+          found: false,
+          error: `Se encontraron ${results.length} código(s) QR pero ninguno de AFIP/ARCA. URLs: ${otherUrls.join(', ')}...`,
+        };
+      }
+
+      return { found: false, error: 'No se encontró código QR en la imagen' };
+    } catch (error) {
+      console.error(`   ❌ Error detectando QR:`, error);
       return { found: false };
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -29,14 +29,14 @@
     "drizzle-orm": "1.0.0-beta.15-859cf75",
     "exceljs": "^4.4.0",
     "heic-convert": "^2.1.0",
-    "jsqr": "^1.4.0",
     "pdf-lib": "^1.17.1",
     "pdf-parse": "^1.1.1",
     "pdf-to-img": "^5.0.0",
     "sharp": "^0.34.5",
     "tesseract.js": "^7.0.0",
     "yaml": "^2.8.1",
-    "zod": "^4.0.0"
+    "zod": "^4.0.0",
+    "zxing-wasm": "3.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.16.0",


### PR DESCRIPTION
## Resumen

Migración del decodificador de QR de jsQR a zxing-wasm (port WASM de la librería ZXing de Google/Android).

**Motivación**: jsQR no puede decodificar QR codes con finder patterns degradados (tickets térmicos Coto, file #176) — ni siquiera con sliding window, multi-scale, preprocessing, ni con un recorte manual humano (~200+ intentos fallidos documentados). zxing-wasm lo resuelve en 25ms sin ningún workaround.

## Benchmark

| Archivo | jsQR | zxing-wasm |
|---|---|---|
| file #162 (factura digital ARCA) | ✅ 478ms (scale 5) | ✅ 106ms (scale 5) — **4.5x más rápido** |
| file #176 (ticket Coto térmico) | ❌ falla en todos los scales y preprocessing | ✅ **25ms** (scale 3) — detecta ARCA QR directamente |

## Cambios

### Extractor principal — `server/extractors/qr-extractor.ts`
- **Reemplazo**: `jsQR` → `readBarcodes` de `zxing-wasm/reader`
- **Eliminados** (workarounds de jsQR que ZXing no necesita):
  - Sliding window (`detectQRInRegion`, `slidingPositions`, `windowConfigs`)
  - Multi-scale rendering (`scales = [3.0, 5.0, 2.0]`, loop de reintentos)
  - Escaneo por regiones
- **Simplificación neta**: ~320 líneas → ~200 líneas (-37%)
- **Conservados**: `parseAFIPJson` (sanitizador de JSON malformado), conversión HEIC, iteración multi-página de PDFs, matching de URLs AFIP, `extract()` público

### Dependencias
- **Agregado**: `zxing-wasm@3.0.2` (reader-only build, ~966 KiB, MIT)
- **Removido**: `jsqr` (ya no se usa en el extractor)

### Toolkit — `scripts/debug/qr/`
- Nuevo: `benchmark.ts` — compara jsQR vs zxing-wasm lado a lado
- Nuevo: `hand-crop.ts` — recorte manual + decode (evidencia de que jsQR falla con recorte humano)
- Actualizado: `raw.ts` migrado a zxing-wasm
- Actualizado: `README.md` con workflow post-migración y scripts legacy documentados
- Scripts legacy (jsQR-specific): `scales.ts`, `preprocess.ts`, `crop-arca.ts` — conservados como documentación, requieren `npm install jsqr` manual

## Test plan

- [x] `npm run check` → 0 errors, 0 warnings
- [x] `npm run test -w server` → 163 passed (los tests de `parseAFIPJson` siguen pasando)
- [x] `npm run debug:qr` contra file #162 → success, confidence 100%
- [x] `npm run debug:qr` contra file #176 (ticket Coto) → **success, confidence 100%** (antes: fallo total)
- [x] `npm run debug:qr:raw` contra ticket Coto → muestra JSON completo de ARCA
- [ ] Verificar en dev que el procesamiento de facturas funciona end-to-end (subir un PDF, verificar extracción)

Relacionado: issue #173 (paste manual fallback queda pendiente como mejora adicional, ya no es urgente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)