### PR TITLE
fix(comprobantes): borrar file pendiente, match a expected balanced, filtro esperadas excluye balanced

### DIFF
--- a/client/src/lib/search/filter-executor.ts
+++ b/client/src/lib/search/filter-executor.ts
@@ -244,8 +244,8 @@ function matchesEstado(c: Comprobante, value: string): boolean {
       // Facturas finalizadas o archivos procesados
       return !!c.final || c.file?.status === 'processed';
     case 'esperadas':
-      // Expected invoices sin factura final
-      return !!c.expected && !c.final;
+      // Expected invoices sin factura final, y que no estén compensadas en balance group
+      return !!c.expected && !c.final && c.expected.status !== 'balanced';
     default:
       return false;
   }

--- a/client/src/routes/comprobantes/[id]/+page.svelte
+++ b/client/src/routes/comprobantes/[id]/+page.svelte
@@ -914,7 +914,14 @@
 
         <!-- Sin factura + sin editMode: solo SourceComparison con botones -->
       {:else if !isExpectedWithoutFile}
-        <!-- El SourceComparison ya se muestra arriba, no necesitamos más acá -->
+        <!-- El SourceComparison ya se muestra arriba; acá solo mostramos la acción de borrado del archivo pendiente -->
+        {#if comprobante.file}
+          <section class="section file-actions-section">
+            <Button size="sm" variant="danger" onclick={() => deleteHandler.open(comprobante)}>
+              Eliminar archivo pendiente
+            </Button>
+          </section>
+        {/if}
 
         <!-- Expected sin archivo: Balance Group (arriba) + mensaje informativo (abajo) -->
       {:else}

--- a/server/database/repositories/expected-invoice.ts
+++ b/server/database/repositories/expected-invoice.ts
@@ -490,7 +490,7 @@ export class ExpectedInvoiceRepository implements IExpectedInvoiceRepository {
       eq(expectedInvoices.cuit, cuitDigits),
       eq(expectedInvoices.pointOfSale, pointOfSale),
       eq(expectedInvoices.invoiceNumber, invoiceNumber),
-      eq(expectedInvoices.status, 'pending'),
+      inArray(expectedInvoices.status, ['pending', 'balanced']),
     ];
 
     // Solo agregar condición de tipo si no es null
@@ -647,7 +647,9 @@ export class ExpectedInvoiceRepository implements IExpectedInvoiceRepository {
     >
   > {
     // Prefiltrar inteligentemente para no perder candidatos por el límite
-    const conditions: (SQL | undefined)[] = [eq(expectedInvoices.status, 'pending')];
+    const conditions: (SQL | undefined)[] = [
+      inArray(expectedInvoices.status, ['pending', 'balanced']),
+    ];
 
     // Aplicar SOLO prefilter de CUIT si disponible (más laxo)
     // Normalize to digits-only for comparison (handles both formats in DB)

--- a/server/extractors/qr-extractor.ts
+++ b/server/extractors/qr-extractor.ts
@@ -179,11 +179,11 @@ export class QRExtractor {
 
       console.info(`   🔍 Buscando código QR AFIP/ARCA (${info.width}x${info.height})...`);
 
-      const imageData: ImageData = {
+      const imageData = {
         data: new Uint8ClampedArray(data),
         width: info.width,
         height: info.height,
-        colorSpace: 'srgb',
+        colorSpace: 'srgb' as const,
       };
 
       const results = await readBarcodes(imageData, {


### PR DESCRIPTION
## Summary

Tres fixes quirúrgicos salidos de un review de uso.

- **Borrar archivo pendiente**: se agregó botón "Eliminar archivo pendiente" en el detalle cuando el comprobante es solo un archivo (sin factura final). El handler y el dialog ya existían — faltaba el trigger UI.
- **Asignar a expected balanced**: `findExactMatch` y `findPartialMatches` ahora consideran `status IN ('pending', 'balanced')`, no solo `pending`. Los miembros de un balance group quedaban invisibles al matcher, así que un PDF correspondiente a un NCRB compensado no podía vincularse.
- **Filtro "esperadas" excluye balanced**: un expected compensado ya no es algo que estés esperando, así que no aparece cuando filtrás por `estado:esperadas`.

De yapa: saqué la anotación `: ImageData` en `qr-extractor.ts` (heredado del merge de zxing-wasm) que rompía el type-check del server tsconfig. Mantuve `colorSpace` como literal para que el client tsconfig siga aceptando la forma.

## Test plan

- [ ] Ver comprobante que es solo un file pendiente (sin factura) y confirmar que aparece el botón "Eliminar archivo pendiente" y que funciona.
- [ ] Subir el PDF de "ARDU NCB 0010-00011192" con el NCRB compensado ya registrado; confirmar que el matcher lo vincula (antes no aparecía).
- [ ] Con un balance group compensado, filtrar por `estado:esperadas` y confirmar que ni principal ni secundarios aparecen.
- [ ] `npm run check` y `npm test` en verde (ya verificado localmente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)