### PR TITLE
feat(qr): paste manual AFIP/ARCA URL fallback

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -121,7 +121,7 @@ Plan de trabajo organizado en fases progresivas, alternando features con tech de
 - [x] #156 - HEIC file preview broken (Content-Type hardcoded a application/pdf) (PR #157)
 - [x] Fix QR serviciosweb.afip.gob.ar URL pattern (PR #165)
 - [x] Fix QR JSON malformado de ARCA (consumidor final sin DNI) + debug toolkit (PR #172)
-- [ ] #173 - QR extraction: paste manual fallback + expand PDF_TEXT para CAE (zxing-wasm ya migrado, PR #174)
+- [ ] #173 - QR extraction: paste URL manual ✅ (PR #177), pendiente expand PDF_TEXT para CAE
 - [ ] #54 - Simplificar algoritmo matching
 - [ ] #93 - Testing extracción docs confidenciales
 - [ ] #129 - Importar desglose impositivo ARCA

--- a/client/src/lib/components/QrPasteDialog.svelte
+++ b/client/src/lib/components/QrPasteDialog.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  /**
+   * Dialog para pegar manualmente una URL de QR AFIP/ARCA cuando el scanner
+   * automático (zxing-wasm) no pudo decodificar el código.
+   *
+   * Caso típico: tickets térmicos Coto muy degradados que iOS/Android sí leen
+   * pero zxing-wasm no. Ver issue #173.
+   */
+
+  import Dialog from './ui/Dialog.svelte';
+  import Button from './ui/Button.svelte';
+
+  type Props = {
+    open: boolean;
+    onsubmit: (qrUrl: string) => Promise<void> | void;
+    onclose: () => void;
+    processing?: boolean;
+    /** Error del último intento (se muestra bajo el textarea) */
+    errorMessage?: string | null;
+  };
+
+  let {
+    open = $bindable(),
+    onsubmit,
+    onclose,
+    processing = false,
+    errorMessage = null,
+  }: Props = $props();
+
+  let qrUrl = $state('');
+
+  const isValidPrefix = $derived(
+    qrUrl.trim().startsWith('https://www.afip.gob.ar/fe/qr/') ||
+      qrUrl.trim().startsWith('https://www.arca.gob.ar/fe/qr/') ||
+      qrUrl.trim().startsWith('https://servicioscf.afip.gob.ar/') ||
+      qrUrl.trim().startsWith('https://serviciosweb.afip.gob.ar/')
+  );
+
+  const canSubmit = $derived(qrUrl.trim().length > 0 && isValidPrefix && !processing);
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+    await onsubmit(qrUrl.trim());
+  }
+
+  function handleOpenChange(isOpen: boolean) {
+    if (!isOpen) {
+      qrUrl = '';
+      onclose();
+    }
+  }
+</script>
+
+<Dialog
+  bind:open
+  title="Pegar URL de QR"
+  description="Si escaneaste el QR con otra app (iOS/Android) y copiaste el link, pegalo acá."
+  onOpenChange={handleOpenChange}
+>
+  <div class="form">
+    <label for="qr-url" class="label">URL del QR AFIP/ARCA</label>
+    <textarea
+      id="qr-url"
+      class="textarea"
+      bind:value={qrUrl}
+      placeholder="https://www.arca.gob.ar/fe/qr/?p=..."
+      rows="4"
+      disabled={processing}
+      spellcheck="false"
+      autocapitalize="off"
+    ></textarea>
+
+    {#if qrUrl.trim().length > 0 && !isValidPrefix}
+      <p class="hint warning">
+        La URL debe empezar con <code>https://www.afip.gob.ar/fe/qr/</code> o
+        <code>https://www.arca.gob.ar/fe/qr/</code>.
+      </p>
+    {/if}
+
+    {#if errorMessage}
+      <p class="hint error">{errorMessage}</p>
+    {/if}
+
+    <div class="actions">
+      <Button variant="secondary" onclick={() => handleOpenChange(false)} disabled={processing}>
+        Cancelar
+      </Button>
+      <Button variant="primary" onclick={handleSubmit} disabled={!canSubmit}>
+        {processing ? 'Procesando…' : 'Procesar URL'}
+      </Button>
+    </div>
+  </div>
+</Dialog>
+
+<style>
+  .form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-3);
+  }
+
+  .label {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-secondary);
+  }
+
+  .textarea {
+    width: 100%;
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-sm);
+    padding: var(--spacing-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    resize: vertical;
+    word-break: break-all;
+  }
+
+  .textarea:focus-visible {
+    outline: 2px solid var(--color-primary-500);
+    outline-offset: 1px;
+    border-color: var(--color-primary-500);
+  }
+
+  .hint {
+    margin: 0;
+    font-size: var(--font-size-xs);
+    line-height: var(--line-height-normal);
+  }
+
+  .hint.warning {
+    color: var(--color-warning-700);
+  }
+
+  .hint.error {
+    color: var(--color-danger-700);
+  }
+
+  .hint code {
+    font-family: var(--font-family-mono);
+    background: var(--color-surface-alt);
+    padding: 0 var(--spacing-1);
+    border-radius: var(--radius-sm);
+  }
+
+  .actions {
+    display: flex;
+    gap: var(--spacing-2);
+    justify-content: flex-end;
+    margin-top: var(--spacing-2);
+  }
+</style>

--- a/client/src/lib/components/ReprocessDialog.svelte
+++ b/client/src/lib/components/ReprocessDialog.svelte
@@ -6,7 +6,7 @@
    */
 
   import Dialog from './ui/Dialog.svelte';
-  import { Check } from 'lucide-svelte';
+  import { Check, QrCode } from 'lucide-svelte';
 
   export type ExtractionMethod = 'ocr' | 'pdf_text' | 'qr';
 
@@ -19,6 +19,10 @@
     fileType?: string | null;
     /** Callback when a method is selected */
     onselect: (method: ExtractionMethod) => void;
+    /** Callback cuando el usuario elige pegar una URL QR manualmente (fallback
+     * para QRs degradados que zxing no puede decodificar). Si no se provee,
+     * la opción no se muestra. */
+    onpasteurl?: () => void;
     /** Callback when dialog is closed */
     onclose: () => void;
     /** Whether processing is in progress */
@@ -30,6 +34,7 @@
     existingMethods = [],
     fileType = null,
     onselect,
+    onpasteurl,
     onclose,
     processing = false,
   }: Props = $props();
@@ -121,6 +126,14 @@
       </span>
       <span class="method-desc">Leer código QR de AFIP/ARCA</span>
     </button>
+
+    {#if onpasteurl}
+      <button type="button" class="method-option" onclick={onpasteurl} disabled={processing}>
+        <span class="method-icon"><QrCode size={20} /></span>
+        <span class="method-name">QR (URL manual)</span>
+        <span class="method-desc">Pegar URL si escaneaste el QR con otra app (iOS/Android)</span>
+      </button>
+    {/if}
   </div>
 
   {#if existingMethods.length > 0}

--- a/client/src/lib/components/SourceComparison.svelte
+++ b/client/src/lib/components/SourceComparison.svelte
@@ -12,6 +12,7 @@
   import CategorySelect from './CategorySelect.svelte';
   import Button from './ui/Button.svelte';
   import ReprocessDialog, { type ExtractionMethod } from './ReprocessDialog.svelte';
+  import QrPasteDialog from './QrPasteDialog.svelte';
   import {
     formatCurrency,
     formatDateShort,
@@ -96,6 +97,9 @@
     oncreatefromexpected?: () => void;
     /** Callback para reprocesar con método específico */
     onreprocess?: (method: ExtractionMethod) => void;
+    /** Callback para enviar una URL de QR pegada manualmente. Debe resolver cuando termina
+     * el procesamiento (éxito o error). Si rechaza, el mensaje se muestra dentro del dialog. */
+    onqrpaste?: (qrUrl: string) => Promise<void>;
     /** Callback para buscar expected manualmente (abre diálogo completo) */
     onsearchexpected?: () => void;
     /** Callback cuando el usuario selecciona un expected alternativo */
@@ -122,6 +126,7 @@
     oncreatefromfile,
     oncreatefromexpected,
     onreprocess,
+    onqrpaste,
     onsearchexpected,
     onexpectedchange,
     onextractionchange,
@@ -294,6 +299,11 @@
   // Estado del diálogo de reprocesamiento
   let reprocessDialogOpen = $state(false);
 
+  // Estado del diálogo de paste URL QR
+  let qrPasteDialogOpen = $state(false);
+  let qrPasteError = $state<string | null>(null);
+  let qrPasteProcessing = $state(false);
+
   // Truncar nombre largo
   const truncateName = (name: string | null | undefined, maxLen: number = 20) => {
     if (!name) return '—';
@@ -328,6 +338,30 @@
 
   function closeReprocessDialog() {
     reprocessDialogOpen = false;
+  }
+
+  function openQrPasteDialog() {
+    qrPasteError = null;
+    qrPasteDialogOpen = true;
+  }
+
+  function closeQrPasteDialog() {
+    qrPasteDialogOpen = false;
+    qrPasteError = null;
+  }
+
+  async function handleQrPasteSubmit(qrUrl: string) {
+    if (!onqrpaste) return;
+    qrPasteError = null;
+    qrPasteProcessing = true;
+    try {
+      await onqrpaste(qrUrl);
+      qrPasteDialogOpen = false;
+    } catch (err) {
+      qrPasteError = err instanceof Error ? err.message : 'Error al procesar la URL';
+    } finally {
+      qrPasteProcessing = false;
+    }
   }
 </script>
 
@@ -707,8 +741,23 @@
   existingMethods={extractions.map((e) => e.method).filter((m): m is string => m != null)}
   fileType={file?.fileType ?? null}
   onselect={handleReprocess}
+  onpasteurl={onqrpaste
+    ? () => {
+        reprocessDialogOpen = false;
+        openQrPasteDialog();
+      }
+    : undefined}
   onclose={closeReprocessDialog}
   {processing}
+/>
+
+<!-- Diálogo de paste URL QR manual (fallback para QRs degradados) -->
+<QrPasteDialog
+  bind:open={qrPasteDialogOpen}
+  onsubmit={handleQrPasteSubmit}
+  onclose={closeQrPasteDialog}
+  processing={qrPasteProcessing}
+  errorMessage={qrPasteError}
 />
 
 <style>

--- a/client/src/lib/services/ComprobanteService.ts
+++ b/client/src/lib/services/ComprobanteService.ts
@@ -177,6 +177,33 @@ class ComprobanteService {
   }
 
   /**
+   * Submit a manually-pasted AFIP/ARCA QR URL as a fallback when zxing can't
+   * decode the embedded QR. Persists a QR extraction with confidence 100%.
+   */
+  async pasteQrUrl(fileId: number, qrUrl: string): Promise<ProcessResult> {
+    try {
+      const response = await fetch(`/api/invoices/qr-paste/${fileId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ qrUrl }),
+      });
+
+      const data = await response.json();
+
+      if (response.ok && data.success) {
+        return {
+          success: true,
+          extraction: { confidence: data.extraction?.confidence || 0 },
+        };
+      }
+      return { success: false, error: data.error || 'Error al procesar URL' };
+    } catch (err) {
+      console.error('Error pasting QR URL:', err);
+      return { success: false, error: 'Error al procesar URL' };
+    }
+  }
+
+  /**
    * Process a file with specified extraction method
    */
   async processFile(fileId: number, method: ExtractionMethod = 'ocr'): Promise<ProcessResult> {

--- a/client/src/routes/api/invoices/qr-paste/[fileId]/+server.ts
+++ b/client/src/routes/api/invoices/qr-paste/[fileId]/+server.ts
@@ -1,0 +1,66 @@
+/**
+ * POST /api/invoices/qr-paste/:fileId
+ *
+ * Fallback manual para cuando zxing-wasm no puede decodificar el QR pero el
+ * usuario sí pudo leerlo con otro scanner (iOS Vision, Android, etc) y tiene
+ * la URL AFIP/ARCA en el portapapeles.
+ *
+ * Persiste el resultado como una extracción QR normal (method=QR, confidence=100
+ * si todos los campos están presentes), quedando indistinguible de un QR
+ * decodificado automáticamente.
+ */
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { QrPasteSchema, formatZodError } from '@server/contracts';
+import { extractFromAFIPUrl } from '@server/extractors/qr-extractor';
+import { getFileRepository, getFileExtractionRepository } from '@server/factories';
+
+export const POST: RequestHandler = async ({ params, request }) => {
+  const fileId = parseInt(params.fileId, 10);
+  if (isNaN(fileId)) {
+    return json({ success: false, error: 'ID de archivo inválido' }, { status: 400 });
+  }
+
+  const body: unknown = await request.json();
+  const parsed = QrPasteSchema.safeParse(body);
+  if (!parsed.success) {
+    return json(formatZodError(parsed.error), { status: 400 });
+  }
+
+  const fileRepo = getFileRepository();
+  const file = await fileRepo.findById(fileId);
+  if (!file) {
+    return json({ success: false, error: 'Archivo no encontrado' }, { status: 404 });
+  }
+
+  const result = extractFromAFIPUrl(parsed.data.qrUrl);
+  if (!result.success) {
+    return json(
+      { success: false, error: result.errors?.[0] || 'URL de QR AFIP/ARCA inválida' },
+      { status: 400 }
+    );
+  }
+
+  const extractionRepo = getFileExtractionRepository();
+  extractionRepo.upsertByMethod(fileId, 'QR', {
+    extractedCuit: result.data.cuit || null,
+    extractedDate: result.data.date || null,
+    extractedTotal: result.data.total ?? null,
+    extractedType: result.data.invoiceType ?? null,
+    extractedPointOfSale: result.data.pointOfSale ?? null,
+    extractedInvoiceNumber: result.data.invoiceNumber ?? null,
+    confidence: result.confidence,
+    errors: null,
+  });
+
+  console.info(`✅ [QR-PASTE] file ${fileId}: extracción persistida (conf ${result.confidence}%)`);
+
+  return json({
+    success: true,
+    extraction: {
+      confidence: result.confidence,
+      data: result.data,
+    },
+  });
+};

--- a/client/src/routes/comprobantes/[id]/+page.svelte
+++ b/client/src/routes/comprobantes/[id]/+page.svelte
@@ -588,6 +588,22 @@
     linkExpectedDialogOpen = false;
   }
 
+  async function handleQrPaste(qrUrl: string): Promise<void> {
+    if (!comprobante.file) throw new Error('Sin archivo');
+    const toastId = toast.loading('Procesando URL del QR...');
+    const result = await comprobanteService.pasteQrUrl(comprobante.file.id, qrUrl);
+    if (result.success) {
+      toast.success(`QR procesado: ${result.extraction?.confidence || 0}% confianza`, {
+        id: toastId,
+      });
+      await invalidateAll();
+      sourceComparisonRef?.selectMostRecent();
+    } else {
+      toast.error(result.error || 'Error', { id: toastId });
+      throw new Error(result.error || 'Error al procesar URL');
+    }
+  }
+
   async function processPending(method?: ExtractionMethod) {
     if (!comprobante.file) return;
 
@@ -773,6 +789,7 @@
               invoiceForm.populateFromExpected(bestExpected, emitterName);
             }}
             onreprocess={processPending}
+            onqrpaste={handleQrPaste}
             onsearchexpected={openLinkExpectedDialog}
             onexpectedchange={(expectedId) => {
               // Seleccionar un expected alternativo - mostrarlo en la comparación

--- a/server/contracts/index.ts
+++ b/server/contracts/index.ts
@@ -25,6 +25,7 @@ export {
   BalanceGroupSetPrincipalSchema,
   BalanceGroupMemberSchema,
   BalanceGroupResponseSchema,
+  QrPasteSchema,
 } from './schemas.js';
 
 export type {
@@ -34,6 +35,7 @@ export type {
   BalanceGroupSetPrincipalInput,
   BalanceGroupMember,
   BalanceGroupResponse,
+  QrPasteInput,
 } from './schemas.js';
 
 // Utilities

--- a/server/contracts/schemas.ts
+++ b/server/contracts/schemas.ts
@@ -199,3 +199,13 @@ export const BalanceGroupResponseSchema = z.object({
 });
 
 export type BalanceGroupResponse = z.infer<typeof BalanceGroupResponseSchema>;
+
+// =============================================================================
+// QR Paste (fallback manual cuando el scanner automático falla)
+// =============================================================================
+
+export const QrPasteSchema = z.object({
+  qrUrl: z.string().trim().min(1, 'URL requerida').max(2048, 'URL demasiado larga'),
+});
+
+export type QrPasteInput = z.infer<typeof QrPasteSchema>;

--- a/server/extractors/qr-extractor.ts
+++ b/server/extractors/qr-extractor.ts
@@ -28,12 +28,16 @@ import convert from 'heic-convert';
 import type { AFIPQRData, QRDetectionResult, AFIPUrlParseResult } from './qr-extractor.types';
 
 // URLs válidas de AFIP/ARCA QR (todos los formatos oficiales)
-const AFIP_QR_URL_PATTERNS = [
+export const AFIP_QR_URL_PATTERNS = [
   'https://www.afip.gob.ar/fe/qr/',
   'https://servicioscf.afip.gob.ar/publico/comprobantes/',
   'https://serviciosweb.afip.gob.ar/genericos/comprobantes/',
   'https://www.arca.gob.ar/fe/qr/', // Nuevo formato ARCA 2024+
 ];
+
+export function isAFIPQrUrl(url: string): boolean {
+  return AFIP_QR_URL_PATTERNS.some((pattern) => url.startsWith(pattern));
+}
 
 // Extensiones de imagen soportadas
 const SUPPORTED_IMAGE_EXTENSIONS = [
@@ -81,6 +85,95 @@ export function parseAFIPJson(jsonStr: string): AFIPQRData {
     const sanitized = jsonStr.replace(/"\s*:\s*(?=[,}\]])/g, '":null');
     return JSON.parse(sanitized) as AFIPQRData;
   }
+}
+
+/**
+ * Parsea URL de AFIP/ARCA y extrae los datos estructurados del QR.
+ * Exportado para que el fallback de paste manual (issue #173) pueda reusar
+ * la misma lógica sin levantar un QRExtractor completo.
+ */
+export function parseAFIPUrl(url: string): AFIPUrlParseResult {
+  if (!isAFIPQrUrl(url)) {
+    return { valid: false, error: `URL no es de AFIP: ${url.substring(0, 50)}...` };
+  }
+
+  let urlObj: URL;
+  try {
+    urlObj = new URL(url);
+  } catch {
+    return { valid: false, error: 'URL malformada' };
+  }
+  const base64Data = urlObj.searchParams.get('p');
+
+  if (!base64Data) {
+    return { valid: false, error: 'URL de AFIP sin parámetro p' };
+  }
+
+  try {
+    const jsonStr = Buffer.from(base64Data, 'base64').toString('utf-8');
+    const data = parseAFIPJson(jsonStr);
+
+    if (!data.ver || !data.cuit) {
+      return { valid: false, error: 'JSON de AFIP con campos faltantes (ver/cuit)' };
+    }
+
+    if (typeof data.fecha !== 'string' || !data.fecha) {
+      console.warn(`   ⚠️ QR AFIP sin fecha válida (fecha=${String(data.fecha)})`);
+    }
+
+    console.info(
+      `   📋 Datos AFIP: CUIT=${data.cuit}, Fecha=${data.fecha || 'N/A'}, Tipo=${data.tipoCmp}`
+    );
+    return { valid: true, data };
+  } catch (error) {
+    return {
+      valid: false,
+      error: `Error parseando JSON: ${error instanceof Error ? error.message : 'desconocido'}`,
+    };
+  }
+}
+
+/**
+ * Construye un ExtractionResult desde una URL AFIP/ARCA ya conocida.
+ * Usado por el fallback de paste manual cuando el usuario copia la URL desde
+ * un scanner externo (ej. iOS Vision, que decodifica QRs más degradados que zxing).
+ */
+export function extractFromAFIPUrl(url: string): ExtractionResult {
+  const parseResult = parseAFIPUrl(url);
+
+  if (!parseResult.valid || !parseResult.data) {
+    return {
+      success: false,
+      confidence: 0,
+      data: {},
+      errors: [parseResult.error || 'URL de QR no válida'],
+      method: 'QR',
+    };
+  }
+
+  const afipData = parseResult.data;
+  const hasValidDate = typeof afipData.fecha === 'string' && afipData.fecha.length > 0;
+  const hasAllRequired =
+    afipData.cuit &&
+    hasValidDate &&
+    afipData.tipoCmp &&
+    afipData.ptoVta !== undefined &&
+    afipData.nroCmp !== undefined;
+  const confidence = hasAllRequired ? 100 : hasValidDate ? 90 : 80;
+
+  return {
+    success: true,
+    confidence,
+    data: {
+      cuit: formatCuit(afipData.cuit),
+      date: hasValidDate ? (afipData.fecha as string) : undefined,
+      total: afipData.importe,
+      invoiceType: afipData.tipoCmp,
+      pointOfSale: afipData.ptoVta,
+      invoiceNumber: afipData.nroCmp,
+    },
+    method: 'QR',
+  };
 }
 
 export class QRExtractor {
@@ -224,53 +317,7 @@ export class QRExtractor {
    * Verifica si una URL es de AFIP (cualquiera de los formatos válidos)
    */
   private isAFIPUrl(url: string): boolean {
-    return AFIP_QR_URL_PATTERNS.some((pattern) => url.startsWith(pattern));
-  }
-
-  /**
-   * Parsea URL de AFIP y extrae datos JSON
-   * Soporta ambos formatos de URL oficiales de AFIP
-   */
-  private parseAFIPUrl(url: string): AFIPUrlParseResult {
-    // Verificar que es URL de AFIP
-    if (!this.isAFIPUrl(url)) {
-      return { valid: false, error: `URL no es de AFIP: ${url.substring(0, 50)}...` };
-    }
-
-    // Extraer parámetro p
-    const urlObj = new URL(url);
-    const base64Data = urlObj.searchParams.get('p');
-
-    if (!base64Data) {
-      return { valid: false, error: 'URL de AFIP sin parámetro p' };
-    }
-
-    try {
-      // Decodificar Base64
-      const jsonStr = Buffer.from(base64Data, 'base64').toString('utf-8');
-      const data = parseAFIPJson(jsonStr);
-
-      // Validar campos mínimos requeridos (CUIT es el único obligatorio)
-      // NOTA: Algunos QR de AFIP tienen "fecha": false en lugar de fecha real
-      if (!data.ver || !data.cuit) {
-        return { valid: false, error: 'JSON de AFIP con campos faltantes (ver/cuit)' };
-      }
-
-      // Advertencia si falta fecha (pero no es error fatal)
-      if (typeof data.fecha !== 'string' || !data.fecha) {
-        console.warn(`   ⚠️ QR AFIP sin fecha válida (fecha=${String(data.fecha)})`);
-      }
-
-      console.info(
-        `   📋 Datos AFIP: CUIT=${data.cuit}, Fecha=${data.fecha || 'N/A'}, Tipo=${data.tipoCmp}`
-      );
-      return { valid: true, data };
-    } catch (error) {
-      return {
-        valid: false,
-        error: `Error parseando JSON: ${error instanceof Error ? error.message : 'desconocido'}`,
-      };
-    }
+    return isAFIPQrUrl(url);
   }
 
   /**
@@ -294,52 +341,14 @@ export class QRExtractor {
         };
       }
 
-      // 2. Parsear URL AFIP
-      const parseResult = this.parseAFIPUrl(qrResult.rawData);
-
-      if (!parseResult.valid || !parseResult.data) {
-        console.warn(`   ⚠️ ${parseResult.error}`);
-        return {
-          success: false,
-          confidence: 30,
-          data: {},
-          errors: [parseResult.error || 'URL de QR no válida'],
-          method: 'QR',
-        };
+      // 2. Parsear URL AFIP + mapear a ExtractionResult
+      const result = extractFromAFIPUrl(qrResult.rawData);
+      if (!result.success) {
+        result.confidence = 30;
+      } else {
+        console.info(`   ✅ Extracción QR exitosa (confianza: ${result.confidence}%)`);
       }
-
-      // 3. Mapear datos AFIP a ExtractionResult
-      const afipData = parseResult.data;
-
-      // Calcular confianza basada en campos presentes
-      // Fecha válida solo si es string (no false o undefined)
-      const hasValidDate = typeof afipData.fecha === 'string' && afipData.fecha.length > 0;
-      const hasAllRequired =
-        afipData.cuit &&
-        hasValidDate &&
-        afipData.tipoCmp &&
-        afipData.ptoVta !== undefined &&
-        afipData.nroCmp !== undefined;
-
-      // Menor confianza si falta fecha
-      const confidence = hasAllRequired ? 100 : hasValidDate ? 90 : 80;
-
-      console.info(`   ✅ Extracción QR exitosa (confianza: ${confidence}%)`);
-
-      return {
-        success: true,
-        confidence,
-        data: {
-          cuit: formatCuit(afipData.cuit),
-          // Solo incluir fecha si es válida (string), no si es false
-          date: hasValidDate ? (afipData.fecha as string) : undefined,
-          total: afipData.importe,
-          invoiceType: afipData.tipoCmp,
-          pointOfSale: afipData.ptoVta,
-          invoiceNumber: afipData.nroCmp,
-        },
-        method: 'QR',
-      };
+      return result;
     } catch (error) {
       console.error(`   ❌ Error en extracción QR:`, error);
       return {


### PR DESCRIPTION
## Contexto

Los tickets térmicos Coto (y otros comprobantes con QRs muy degradados) a veces no pueden ser decodificados por zxing-wasm — aunque iOS Vision u otros scanners sí los leen. Hasta ahora, cuando zxing fallaba, el usuario se quedaba sin forma de procesar el comprobante automáticamente.

Casos concretos que motivaron esto: files 188 y 189 (dos Coto de marzo). Uno zxing no lo encuentra, el otro solo encuentra el QR propio de Coto pero no el de ARCA. iOS los lee a los dos.

Cierra parcialmente issue #173 (queda pendiente el expand de PDF_TEXT para CAE).

## Cambios

- **Refactor**: `parseAFIPUrl` + `extractFromAFIPUrl` + `isAFIPQrUrl` expuestos como top-level en `server/extractors/qr-extractor.ts`. El método de la clase `QRExtractor` ahora los consume.
- **Endpoint**: `POST /api/invoices/qr-paste/:fileId` recibe `{ qrUrl }`, valida con Zod, y persiste con `upsertByMethod('QR', ...)` — la extracción queda indistinguible de una del scanner automático.
- **UI**: nueva opción "QR (URL manual)" dentro del diálogo existente **Reprocesar archivo**, al final de OCR/PDF Text/QR. Al elegirla se abre un segundo dialog (`QrPasteDialog`) con un textarea para la URL. Validación client-side de prefijo AFIP/ARCA, errores del servidor se muestran inline.

## Flujo del usuario

1. Abre el drawer del comprobante.
2. Click en botón Reprocesar → dialog muestra 4 opciones.
3. Elige "QR (URL manual)" → segundo dialog con textarea.
4. Pega la URL copiada de iOS (`https://www.arca.gob.ar/fe/qr/?p=...`).
5. Procesar → extracción persistida, UI se refresca y selecciona la nueva entry.

## Test plan

- [x] Tests unitarios de `parseAFIPJson` (pre-existentes) siguen pasando
- [x] `svelte-check` sin errores ni warnings
- [x] Endpoint probado con curl: caso OK (confianza 100%), URL no-AFIP (400), URL sin `p` (400), fileId inexistente (404), body sin `qrUrl` (Zod 400)
- [ ] Probar en browser con files 188 y 189 usando URL real escaneada con iOS
- [ ] Verificar que el comprobante pasa a matched después del paste

🤖 Generated with [Claude Code](https://claude.com/claude-code)