### PR TITLE
ci: subir heap a 6GB en build de release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
 
       - name: Build application
         run: npm run build
+        env:
+          # vite build se queda sin heap (default ~4GB) bundleando googleapis + Svelte server.
+          # Hasta que la integración con Google quede out, subimos el heap.
+          NODE_OPTIONS: --max-old-space-size=6144
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Resumen

El workflow Release corre `npm run build` con heap default (~4GB) y revienta con `Reached heap limit Allocation failed` durante `vite build`. Sube `NODE_OPTIONS=--max-old-space-size=6144` para desbloquear releases.

## Contexto

- Bloqueó el release **v0.8.0** ([run #25773513087](https://github.com/genuinefafa/simple-procesador-facturas/actions/runs/25773513087)) → imagen `latest` quedó stale (de v0.7.0).
- Causa raíz probable: bundle de `googleapis` + chunks de Svelte server pesados.
- Fix complementario (en otra PR): quitar Google del repo. Cuando eso esté, este patch deja de ser necesario.

## Test plan

- [ ] Mergear y re-cortar v0.8.0
- [ ] Verificar que el workflow llega al push de imagen sin OOM