### PR TITLE
chore: ignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,8 +108,9 @@ server/config.json
 .local-invoice-categories.json
 categorias.json
 
-# Claude Code settings
+# Claude Code settings + runtime artifacts
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Archivos de prueba generados
 test-output/


### PR DESCRIPTION
## Summary

Add `.claude/scheduled_tasks.lock` to `.gitignore`. Runtime lock file from claude-code ScheduleWakeup; not project state.

## Test plan

- [ ] No further effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)